### PR TITLE
select transaction reference and scan in each row

### DIFF
--- a/storage/postgres/transactions.go
+++ b/storage/postgres/transactions.go
@@ -148,6 +148,7 @@ func (s *PGStore) FindTransactions(q query.Query) (query.Cursor, error) {
 		"t.id",
 		"t.timestamp",
 		"t.hash",
+		"t.reference",
 		"p.source",
 		"p.destination",
 		"p.amount",
@@ -176,6 +177,7 @@ func (s *PGStore) FindTransactions(q query.Query) (query.Cursor, error) {
 		var txid int64
 		var ts string
 		var thash string
+		var tref string
 
 		posting := core.Posting{}
 
@@ -183,6 +185,7 @@ func (s *PGStore) FindTransactions(q query.Query) (query.Cursor, error) {
 			&txid,
 			&ts,
 			&thash,
+			&tref,
 			&posting.Source,
 			&posting.Destination,
 			&posting.Amount,
@@ -195,6 +198,7 @@ func (s *PGStore) FindTransactions(q query.Query) (query.Cursor, error) {
 				Postings:  []core.Posting{},
 				Timestamp: ts,
 				Hash:      thash,
+				Reference: tref,
 				Metadata:  core.Metadata{},
 			}
 		}

--- a/storage/sqlite/transactions.go
+++ b/storage/sqlite/transactions.go
@@ -39,6 +39,7 @@ func (s *SQLiteStore) FindTransactions(q query.Query) (query.Cursor, error) {
 		"t.id",
 		"t.timestamp",
 		"t.hash",
+		"t.reference",
 		"p.source",
 		"p.destination",
 		"p.amount",
@@ -69,6 +70,7 @@ func (s *SQLiteStore) FindTransactions(q query.Query) (query.Cursor, error) {
 		var txid int64
 		var ts string
 		var thash string
+		var tref string
 
 		posting := core.Posting{}
 
@@ -76,6 +78,7 @@ func (s *SQLiteStore) FindTransactions(q query.Query) (query.Cursor, error) {
 			&txid,
 			&ts,
 			&thash,
+			&tref,
 			&posting.Source,
 			&posting.Destination,
 			&posting.Amount,
@@ -88,6 +91,7 @@ func (s *SQLiteStore) FindTransactions(q query.Query) (query.Cursor, error) {
 				Postings:  []core.Posting{},
 				Timestamp: ts,
 				Hash:      thash,
+				Reference: tref,
 				Metadata:  core.Metadata{},
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Henry Jackson <henry.jackson.95@gmail.com>

After posting the transaction given as an example in the issue, reference is now populated in the response body when querying

```
▶ curl -X GET http://localhost:3068/test-01/transactions | jq .                                                                                              
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   352  100   352    0     0   114k      0 --:--:-- --:--:-- --:--:--  171k
{
  "cursor": {
    "page_size": 15,
    "has_more": false,
    "total": 1,
    "remaining_results": 0,
    "data": [
      {
        "txid": 0,
        "postings": [
          {
            "source": "world",
            "destination": "test:001",
            "amount": 100,
            "asset": "USD/2"
          }
        ],
        "reference": "foobar",
        "timestamp": "2021-10-18T21:33:18-04:00",
        "hash": "fb6943243f30f1f7130acc3c6259c392888141d2f25c805bea195531f33a49d4",
        "metadata": {}
      }
    ]
  },
  "err": null,
  "ok": true
}
```

Solves #48 