### PR TITLE
implement meta id and timestamp logic

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -17,9 +17,10 @@ import (
 
 type Ledger struct {
 	sync.Mutex
-	name  string
-	store storage.Store
-	_last *core.Transaction
+	name        string
+	store       storage.Store
+	_last       *core.Transaction
+	_lastMetaID int
 }
 
 func NewLedger(name string, lc fx.Lifecycle) (*Ledger, error) {
@@ -196,15 +197,23 @@ func (l *Ledger) RevertTransaction(id string) error {
 		return err
 	}
 
+	if l._last == nil {
+		last, err := l.GetLastTransaction()
+
+		if err != nil {
+			return err
+		}
+
+		l._last = &last
+	}
+
 	rt := tx.Reverse()
+	rt.Metadata = core.Metadata{}
+	rt.Metadata.MarkRevertedBy(fmt.Sprint(l._last.ID))
 	err = l.Commit([]core.Transaction{rt})
 	if err != nil {
 		return err
 	}
-
-	m := core.Metadata{}
-	m.MarkRevertedBy(fmt.Sprint(l._last.ID))
-	err = l.SaveMeta("transaction", fmt.Sprint(l._last.ID), m)
 
 	return err
 }
@@ -248,6 +257,41 @@ func (l *Ledger) GetAccount(address string) (core.Account, error) {
 	return account, nil
 }
 
-func (l *Ledger) SaveMeta(ty string, id string, m core.Metadata) error {
-	return l.store.SaveMeta(ty, id, m)
+func (l *Ledger) SaveMeta(targetType string, targetID string, m core.Metadata) error {
+	l.Lock()
+	defer l.Unlock()
+
+	if l._lastMetaID == 0 {
+		lastID, err := l.getLastMetaID()
+		if err != nil {
+			return err
+		}
+		l._lastMetaID = lastID
+	}
+
+	metaRowID := fmt.Sprint(l._lastMetaID)
+	timestamp := time.Now().Format(time.RFC3339)
+
+	err := l.store.SaveMeta(metaRowID, timestamp, targetType, targetID, m)
+	if err != nil {
+		l._lastMetaID++
+	}
+	return err
+}
+
+func (l *Ledger) getLastMetaID() (int, error) {
+	q := query.New()
+	q.Modify(query.Limit(1))
+
+	c, err := l.store.FindMeta(q)
+
+	if err != nil {
+		return 0, err
+	}
+
+	mds := (c.Data).([]core.Metadata)
+
+	id := len(mds) - 1
+
+	return id, nil
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -282,11 +282,10 @@ func (l *Ledger) SaveMeta(targetType string, targetID string, m core.Metadata) e
 			key,
 			string(value),
 		)
-		if err == nil {
-			l._lastMetaID++
-		} else {
+		if err != nil {
 			return err
 		}
+		l._lastMetaID++
 	}
 	return nil
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -20,7 +20,7 @@ type Ledger struct {
 	name        string
 	store       storage.Store
 	_last       *core.Transaction
-	_lastMetaID int
+	_lastMetaID int64
 }
 
 func NewLedger(name string, lc fx.Lifecycle) (*Ledger, error) {
@@ -263,9 +263,8 @@ func (l *Ledger) SaveMeta(targetType string, targetID string, m core.Metadata) e
 		if err != nil {
 			return err
 		}
-		l._lastMetaID = int(count) - 1
+		l._lastMetaID = count
 	}
-
 	timestamp := time.Now().Format(time.RFC3339)
 
 	for key, value := range m {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -211,9 +211,6 @@ func (l *Ledger) RevertTransaction(id string) error {
 	rt.Metadata = core.Metadata{}
 	rt.Metadata.MarkRevertedBy(fmt.Sprint(l._last.ID))
 	err = l.Commit([]core.Transaction{rt})
-	if err != nil {
-		return err
-	}
 
 	return err
 }

--- a/ledger/query/cursor.go
+++ b/ledger/query/cursor.go
@@ -3,7 +3,7 @@ package query
 type Cursor struct {
 	PageSize  int         `json:"page_size"`
 	HasMore   bool        `json:"has_more"`
-	Total     int         `json:"total,omitempty"`
+	Total     int64       `json:"total,omitempty"`
 	Remaining int         `json:"remaining_results"`
 	Previous  string      `json:"previous,omitempty"`
 	Next      string      `json:"next,omitempty"`

--- a/storage/postgres/accounts.go
+++ b/storage/postgres/accounts.go
@@ -100,7 +100,7 @@ func (s *PGStore) FindAccounts(q query.Query) (query.Cursor, error) {
 	c.PageSize = q.Limit
 	c.HasMore = len(results) < remaining
 	c.Remaining = remaining - len(results)
-	c.Total = int(total)
+	c.Total = total
 	c.Data = results
 
 	return c, nil

--- a/storage/postgres/aggregations.go
+++ b/storage/postgres/aggregations.go
@@ -12,8 +12,10 @@ func (s *PGStore) CountMeta() (int64, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 
 	sb.
-		Select("count(*)").
+		Select("meta_id").
 		From("metadata").
+		OrderBy("meta_id desc").
+		Limit(1).
 		BuildWithFlavor(sqlbuilder.PostgreSQL)
 
 	sqlq, args := sb.Build()

--- a/storage/postgres/aggregations.go
+++ b/storage/postgres/aggregations.go
@@ -6,6 +6,27 @@ import (
 	"github.com/huandu/go-sqlbuilder"
 )
 
+func (s *PGStore) CountMeta() (int64, error) {
+	var count int64
+
+	sb := sqlbuilder.NewSelectBuilder()
+
+	sb.
+		Select("count(*)").
+		From("metadata").
+		BuildWithFlavor(sqlbuilder.PostgreSQL)
+
+	sqlq, args := sb.Build()
+
+	err := s.Conn().QueryRow(
+		context.Background(),
+		sqlq,
+		args...,
+	).Scan(&count)
+
+	return count, err
+}
+
 func (s *PGStore) AggregateBalances(address string) (map[string]int64, error) {
 	balances := map[string]int64{}
 

--- a/storage/postgres/metadata.go
+++ b/storage/postgres/metadata.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/ledger/core"
-	"github.com/numary/ledger/ledger/query"
 	"github.com/spf13/viper"
 )
 
@@ -32,7 +30,7 @@ func (s *PGStore) GetMeta(ty string, id string) (core.Metadata, error) {
 	}
 
 	rows, err := s.Conn().Query(
-		context.TODO(),
+		context.Background(),
 		sqlq,
 		args...,
 	)
@@ -71,7 +69,7 @@ func (s *PGStore) GetMeta(ty string, id string) (core.Metadata, error) {
 }
 
 func (s *PGStore) SaveMeta(id, timestamp, targetType, targetID, key, value string) error {
-	tx, _ := s.Conn().Begin(context.TODO())
+	tx, _ := s.Conn().Begin(context.Background())
 
 	ib := sqlbuilder.NewInsertBuilder()
 	ib.InsertInto(s.table("metadata"))
@@ -88,106 +86,22 @@ func (s *PGStore) SaveMeta(id, timestamp, targetType, targetID, key, value strin
 	sqlq, args := ib.BuildWithFlavor(sqlbuilder.PostgreSQL)
 
 	_, err := tx.Exec(
-		context.TODO(),
+		context.Background(),
 		sqlq,
 		args...,
 	)
 
 	if err != nil {
-		tx.Rollback(context.TODO())
+		tx.Rollback(context.Background())
 
 		return err
 	}
 
-	err = tx.Commit(context.TODO())
+	err = tx.Commit(context.Background())
 
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (s *PGStore) FindMeta(q query.Query) (query.Cursor, error) {
-	q.Limit = int(math.Max(-1, math.Min(float64(q.Limit), 100))) + 1
-
-	c := query.Cursor{}
-
-	in := sqlbuilder.NewSelectBuilder()
-	in.Select(
-		"meta_id",
-		"meta_target_type",
-		"meta_target_id",
-		"meta_key",
-		"meta_value",
-	)
-	in.From("metadata")
-	in.OrderBy("meta_id desc")
-	in.Limit(q.Limit)
-
-	sqlq, args := in.BuildWithFlavor(sqlbuilder.PostgreSQL)
-	if viper.GetBool("debug") {
-		fmt.Println(sqlq, args)
-	}
-
-	rows, err := s.Conn().Query(
-		context.TODO(),
-		sqlq,
-		args...,
-	)
-
-	if err != nil {
-		return c, err
-	}
-
-	foundMetadata := map[int64]core.Metadata{}
-
-	for rows.Next() {
-
-		md := core.Metadata{}
-
-		var (
-			metaID     int64
-			targetType string
-			targetID   string
-			metaKey    string
-			metaValue  string
-		)
-
-		rows.Scan(
-			&metaID,
-			&targetType,
-			&targetID,
-			&metaKey,
-			&metaValue,
-		)
-
-		var value json.RawMessage
-
-		err = json.Unmarshal([]byte(metaValue), &value)
-		if err != nil {
-			return c, err
-		}
-
-		md[metaKey] = value
-		foundMetadata[metaID] = md
-	}
-
-	results := make([]core.Metadata, len(foundMetadata))
-	for id, md := range foundMetadata {
-		results[id] = md
-	}
-
-	c.PageSize = q.Limit - 1
-
-	c.HasMore = len(results) == q.Limit
-	if c.HasMore {
-		results = results[:len(results)-1]
-	}
-	c.Data = results
-
-	total, _ := s.CountMeta()
-	c.Total = int(total)
-
-	return c, nil
 }

--- a/storage/postgres/metadata.go
+++ b/storage/postgres/metadata.go
@@ -70,38 +70,36 @@ func (s *PGStore) GetMeta(ty string, id string) (core.Metadata, error) {
 	return meta, nil
 }
 
-func (s *PGStore) SaveMeta(id, timestamp, targetType, targetID string, m core.Metadata) error {
+func (s *PGStore) SaveMeta(id, timestamp, targetType, targetID, key, value string) error {
 	tx, _ := s.Conn().Begin(context.TODO())
 
-	for key, value := range m {
-		ib := sqlbuilder.NewInsertBuilder()
-		ib.InsertInto(s.table("metadata"))
-		ib.Cols(
-			"meta_id",
-			"meta_target_type",
-			"meta_target_id",
-			"meta_key",
-			"meta_value",
-			"timestamp",
-		)
-		ib.Values(id, targetType, targetID, key, string(value), timestamp)
+	ib := sqlbuilder.NewInsertBuilder()
+	ib.InsertInto(s.table("metadata"))
+	ib.Cols(
+		"meta_id",
+		"meta_target_type",
+		"meta_target_id",
+		"meta_key",
+		"meta_value",
+		"timestamp",
+	)
+	ib.Values(id, targetType, targetID, key, string(value), timestamp)
 
-		sqlq, args := ib.BuildWithFlavor(sqlbuilder.PostgreSQL)
+	sqlq, args := ib.BuildWithFlavor(sqlbuilder.PostgreSQL)
 
-		_, err := tx.Exec(
-			context.TODO(),
-			sqlq,
-			args...,
-		)
+	_, err := tx.Exec(
+		context.TODO(),
+		sqlq,
+		args...,
+	)
 
-		if err != nil {
-			tx.Rollback(context.TODO())
+	if err != nil {
+		tx.Rollback(context.TODO())
 
-			return err
-		}
+		return err
 	}
 
-	err := tx.Commit(context.TODO())
+	err = tx.Commit(context.TODO())
 
 	if err != nil {
 		return err

--- a/storage/postgres/metadata.go
+++ b/storage/postgres/metadata.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/ledger/core"
+	"github.com/numary/ledger/ledger/query"
 	"github.com/spf13/viper"
 )
 
@@ -68,19 +70,21 @@ func (s *PGStore) GetMeta(ty string, id string) (core.Metadata, error) {
 	return meta, nil
 }
 
-func (s *PGStore) SaveMeta(ty string, id string, m core.Metadata) error {
+func (s *PGStore) SaveMeta(id, timestamp, targetType, targetID string, m core.Metadata) error {
 	tx, _ := s.Conn().Begin(context.TODO())
 
 	for key, value := range m {
 		ib := sqlbuilder.NewInsertBuilder()
 		ib.InsertInto(s.table("metadata"))
 		ib.Cols(
+			"meta_id",
 			"meta_target_type",
 			"meta_target_id",
 			"meta_key",
 			"meta_value",
+			"timestamp",
 		)
-		ib.Values(ty, id, key, string(value))
+		ib.Values(id, targetType, targetID, key, string(value), timestamp)
 
 		sqlq, args := ib.BuildWithFlavor(sqlbuilder.PostgreSQL)
 
@@ -104,4 +108,88 @@ func (s *PGStore) SaveMeta(ty string, id string, m core.Metadata) error {
 	}
 
 	return nil
+}
+
+func (s *PGStore) FindMeta(q query.Query) (query.Cursor, error) {
+	q.Limit = int(math.Max(-1, math.Min(float64(q.Limit), 100))) + 1
+
+	c := query.Cursor{}
+
+	in := sqlbuilder.NewSelectBuilder()
+	in.Select(
+		"meta_id",
+		"meta_target_type",
+		"meta_target_id",
+		"meta_key",
+		"meta_value",
+	)
+	in.From("metadata")
+	in.OrderBy("meta_id desc")
+	in.Limit(q.Limit)
+
+	sqlq, args := in.BuildWithFlavor(sqlbuilder.PostgreSQL)
+	if viper.GetBool("debug") {
+		fmt.Println(sqlq, args)
+	}
+
+	rows, err := s.Conn().Query(
+		context.TODO(),
+		sqlq,
+		args...,
+	)
+
+	if err != nil {
+		return c, err
+	}
+
+	foundMetadata := map[int64]core.Metadata{}
+
+	for rows.Next() {
+
+		md := core.Metadata{}
+
+		var (
+			metaID     int64
+			targetType string
+			targetID   string
+			metaKey    string
+			metaValue  string
+		)
+
+		rows.Scan(
+			&metaID,
+			&targetType,
+			&targetID,
+			&metaKey,
+			&metaValue,
+		)
+
+		var value json.RawMessage
+
+		err = json.Unmarshal([]byte(metaValue), &value)
+		if err != nil {
+			return c, err
+		}
+
+		md[metaKey] = value
+		foundMetadata[metaID] = md
+	}
+
+	results := make([]core.Metadata, len(foundMetadata))
+	for id, md := range foundMetadata {
+		results[id] = md
+	}
+
+	c.PageSize = q.Limit - 1
+
+	c.HasMore = len(results) == q.Limit
+	if c.HasMore {
+		results = results[:len(results)-1]
+	}
+	c.Data = results
+
+	total, _ := s.CountMeta()
+	c.Total = int(total)
+
+	return c, nil
 }

--- a/storage/postgres/store.go
+++ b/storage/postgres/store.go
@@ -25,7 +25,7 @@ func (s *PGStore) connect() error {
 	log.Println("initiating postgres pool")
 
 	pool, err := pgxpool.Connect(
-		context.TODO(),
+		context.Background(),
 		s.connString,
 	)
 

--- a/storage/postgres/transactions.go
+++ b/storage/postgres/transactions.go
@@ -169,7 +169,7 @@ func (s *PGStore) FindTransactions(q query.Query) (query.Cursor, error) {
 	sqlq, args := sb.BuildWithFlavor(sqlbuilder.PostgreSQL)
 
 	rows, err := s.Conn().Query(
-		context.TODO(),
+		context.Background(),
 		sqlq,
 		args...,
 	)
@@ -259,7 +259,7 @@ func (s *PGStore) GetTransaction(id string) (core.Transaction, error) {
 	tx := core.Transaction{}
 
 	rows, err := s.Conn().Query(
-		context.TODO(),
+		context.Background(),
 		sqlq,
 		args...,
 	)

--- a/storage/sqlite/accounts.go
+++ b/storage/sqlite/accounts.go
@@ -74,7 +74,7 @@ func (s *SQLiteStore) FindAccounts(q query.Query) (query.Cursor, error) {
 	c.Data = results
 
 	total, _ := s.CountAccounts()
-	c.Total = int(total)
+	c.Total = total
 
 	return c, nil
 }

--- a/storage/sqlite/aggregations.go
+++ b/storage/sqlite/aggregations.go
@@ -35,6 +35,23 @@ func (s *SQLiteStore) CountAccounts() (int64, error) {
 	return count, err
 }
 
+func (s *SQLiteStore) CountMeta() (int64, error) {
+	var count int64
+
+	sb := sqlbuilder.NewSelectBuilder()
+
+	sb.
+		Select("count(*)").
+		From("metadata").
+		BuildWithFlavor(sqlbuilder.SQLite)
+
+	sqlq, args := sb.Build()
+
+	err := s.db.QueryRow(sqlq, args...).Scan(&count)
+
+	return count, err
+}
+
 func (s *SQLiteStore) AggregateBalances(address string) (map[string]int64, error) {
 	balances := map[string]int64{}
 

--- a/storage/sqlite/aggregations.go
+++ b/storage/sqlite/aggregations.go
@@ -41,8 +41,10 @@ func (s *SQLiteStore) CountMeta() (int64, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 
 	sb.
-		Select("count(*)").
+		Select("meta_id").
 		From("metadata").
+		OrderBy("meta_id desc").
+		Limit(1).
 		BuildWithFlavor(sqlbuilder.SQLite)
 
 	sqlq, args := sb.Build()

--- a/storage/sqlite/metadata.go
+++ b/storage/sqlite/metadata.go
@@ -65,41 +65,43 @@ func (s *SQLiteStore) GetMeta(ty string, id string) (core.Metadata, error) {
 	return meta, nil
 }
 
-func (s *SQLiteStore) SaveMeta(id, timestamp, targetType, targetID string, m core.Metadata) error {
+func (s *SQLiteStore) SaveMeta(id, timestamp, targetType, targetID, key, value string) error {
 	tx, _ := s.db.Begin()
 
-	for key, value := range m {
-		ib := sqlbuilder.NewInsertBuilder()
-		ib.InsertInto("metadata")
-		ib.Cols(
-			"meta_id",
-			"meta_target_type",
-			"meta_target_id",
-			"meta_key",
-			"meta_value",
-			"timestamp",
-		)
-		ib.Values(
-			id,
-			targetType,
-			targetID,
-			key,
-			string(value),
-			timestamp,
-		)
+	ib := sqlbuilder.NewInsertBuilder()
+	ib.InsertInto("metadata")
+	ib.Cols(
+		"meta_id",
+		"meta_target_type",
+		"meta_target_id",
+		"meta_key",
+		"meta_value",
+		"timestamp",
+	)
+	ib.Values(
+		id,
+		targetType,
+		targetID,
+		key,
+		string(value),
+		timestamp,
+	)
 
-		sqlq, args := ib.BuildWithFlavor(sqlbuilder.SQLite)
-
-		_, err := tx.Exec(sqlq, args...)
-
-		if err != nil {
-			tx.Rollback()
-
-			return err
-		}
+	sqlq, args := ib.BuildWithFlavor(sqlbuilder.SQLite)
+	if viper.GetBool("debug") {
+		fmt.Println(sqlq, args)
 	}
 
-	err := tx.Commit()
+	_, err := tx.Exec(sqlq, args...)
+
+	if err != nil {
+		fmt.Println("failed to save metadata", err)
+		tx.Rollback()
+
+		return err
+	}
+
+	err = tx.Commit()
 
 	if err != nil {
 		return err

--- a/storage/sqlite/metadata.go
+++ b/storage/sqlite/metadata.go
@@ -3,9 +3,11 @@ package sqlite
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/ledger/core"
+	"github.com/numary/ledger/ledger/query"
 	"github.com/spf13/viper"
 )
 
@@ -63,19 +65,28 @@ func (s *SQLiteStore) GetMeta(ty string, id string) (core.Metadata, error) {
 	return meta, nil
 }
 
-func (s *SQLiteStore) SaveMeta(ty string, id string, m core.Metadata) error {
+func (s *SQLiteStore) SaveMeta(id, timestamp, targetType, targetID string, m core.Metadata) error {
 	tx, _ := s.db.Begin()
 
 	for key, value := range m {
 		ib := sqlbuilder.NewInsertBuilder()
 		ib.InsertInto("metadata")
 		ib.Cols(
+			"meta_id",
 			"meta_target_type",
 			"meta_target_id",
 			"meta_key",
 			"meta_value",
+			"timestamp",
 		)
-		ib.Values(ty, id, key, string(value))
+		ib.Values(
+			id,
+			targetType,
+			targetID,
+			key,
+			string(value),
+			timestamp,
+		)
 
 		sqlq, args := ib.BuildWithFlavor(sqlbuilder.SQLite)
 
@@ -95,4 +106,88 @@ func (s *SQLiteStore) SaveMeta(ty string, id string, m core.Metadata) error {
 	}
 
 	return nil
+}
+
+func (s *SQLiteStore) FindMeta(q query.Query) (query.Cursor, error) {
+	q.Limit = int(math.Max(-1, math.Min(float64(q.Limit), 100))) + 1
+
+	c := query.Cursor{}
+
+	in := sqlbuilder.NewSelectBuilder()
+	in.Select(
+		"meta_id",
+		"meta_target_type",
+		"meta_target_id",
+		"meta_key",
+		"meta_value",
+	)
+	in.From("metadata")
+	in.OrderBy("meta_id desc")
+	in.Limit(q.Limit)
+
+	sqlq, args := in.BuildWithFlavor(sqlbuilder.SQLite)
+	if viper.GetBool("debug") {
+		fmt.Println(sqlq, args)
+	}
+
+	rows, err := s.db.Query(
+		sqlq,
+		args...,
+	)
+
+	if err != nil {
+		return c, err
+	}
+
+	foundMetadata := map[int64]core.Metadata{}
+
+	for rows.Next() {
+
+		fmt.Println("rows.Next()")
+		md := core.Metadata{}
+
+		var (
+			metaID     int64
+			targetType string
+			targetID   string
+			metaKey    string
+			metaValue  string
+		)
+
+		rows.Scan(
+			&metaID,
+			&targetType,
+			&targetID,
+			&metaKey,
+			&metaValue,
+		)
+
+		var value json.RawMessage
+
+		err = json.Unmarshal([]byte(metaValue), &value)
+		if err != nil {
+			return c, err
+		}
+
+		md[metaKey] = value
+		foundMetadata[metaID] = md
+	}
+
+	results := make([]core.Metadata, len(foundMetadata))
+	for id, md := range foundMetadata {
+		results[id] = md
+	}
+
+	c.PageSize = q.Limit - 1
+
+	c.HasMore = len(results) == q.Limit
+	if c.HasMore {
+		results = results[:len(results)-1]
+	}
+	c.Data = results
+
+	total, _ := s.CountMeta()
+	c.Total = int(total)
+
+	return c, nil
 }

--- a/storage/sqlite/transactions.go
+++ b/storage/sqlite/transactions.go
@@ -142,7 +142,7 @@ func (s *SQLiteStore) FindTransactions(q query.Query) (query.Cursor, error) {
 	c.Data = results
 
 	total, _ := s.CountTransactions()
-	c.Total = int(total)
+	c.Total = total
 
 	return c, nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,8 +18,10 @@ type Store interface {
 	AggregateVolumes(string) (map[string]map[string]int64, error)
 	CountAccounts() (int64, error)
 	FindAccounts(query.Query) (query.Cursor, error)
-	SaveMeta(string, string, core.Metadata) error
+	SaveMeta(string, string, string, string, core.Metadata) error
 	GetMeta(string, string) (core.Metadata, error)
+	FindMeta(query.Query) (query.Cursor, error)
+	CountMeta() (int64, error)
 	Initialize() error
 	Close()
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -20,7 +20,6 @@ type Store interface {
 	FindAccounts(query.Query) (query.Cursor, error)
 	SaveMeta(string, string, string, string, string, string) error
 	GetMeta(string, string) (core.Metadata, error)
-	FindMeta(query.Query) (query.Cursor, error)
 	CountMeta() (int64, error)
 	Initialize() error
 	Close()

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,7 +18,7 @@ type Store interface {
 	AggregateVolumes(string) (map[string]map[string]int64, error)
 	CountAccounts() (int64, error)
 	FindAccounts(query.Query) (query.Cursor, error)
-	SaveMeta(string, string, string, string, core.Metadata) error
+	SaveMeta(string, string, string, string, string, string) error
 	GetMeta(string, string) (core.Metadata, error)
 	FindMeta(query.Query) (query.Cursor, error)
 	CountMeta() (int64, error)


### PR DESCRIPTION
closes #63 

Can be tested by posting metadata to a transaction (using quickstart transaction data from README):

```sh
curl -X POST -H "Content-Type: application/json" http://localhost:3068/quickstart/transactions/0/metadata -d \
'{
   "transaction-type": "driver-payout",
   "ride-type": "standard"
 }'
```

Checking db:
```
sqlite> select * from metadata;
meta_id  meta_target_type  meta_target_id  meta_key                  meta_value       timestamp
-------  ----------------  --------------  ------------------------  ---------------  -------------------------
0        transaction       0               transaction-type          "driver-payout"  2021-11-06T13:53:08-04:00
1        transaction       0               ride-type                 "standard"       2021-11-06T13:53:08-04:00
```