### PR TITLE
refactor(query): refactor the query building using structs and builders

### DIFF
--- a/pkg/api/controllers/account_controller.go
+++ b/pkg/api/controllers/account_controller.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/gin-gonic/gin"
 	"github.com/numary/go-libs/sharedapi"
 	"github.com/numary/ledger/pkg/core"
 	"github.com/numary/ledger/pkg/ledger"
 	"github.com/numary/ledger/pkg/storage"
 	"github.com/numary/ledger/pkg/storage/sqlstorage"
-	"net/http"
-	"strconv"
 )
 
 type AccountController struct{}

--- a/pkg/api/controllers/script_controller_test.go
+++ b/pkg/api/controllers/script_controller_test.go
@@ -104,7 +104,11 @@ func TestPostScriptPreview(t *testing.T) {
 					res := controllers.ScriptResponse{}
 					internal.Decode(t, rsp.Body, &res)
 
-					cursor, err := store.GetTransactions(ctx, storage.NewTransactionsQuery())
+					cursor, err := store.GetTransactions(ctx, storage.NewTransactionsQuery(
+						0,
+						0,
+						&storage.TransactionsQueryFilters{},
+					))
 					assert.NoError(t, err)
 					assert.Len(t, cursor.Data, 0)
 				})
@@ -121,7 +125,10 @@ func TestPostScriptPreview(t *testing.T) {
 					res := controllers.ScriptResponse{}
 					internal.Decode(t, rsp.Body, &res)
 
-					cursor, err := store.GetTransactions(ctx, storage.NewTransactionsQuery())
+					cursor, err := store.GetTransactions(ctx, storage.NewTransactionsQuery(
+						0,
+						0,
+						&storage.TransactionsQueryFilters{}))
 					assert.NoError(t, err)
 					assert.Len(t, cursor.Data, 1)
 				})

--- a/pkg/api/controllers/script_controller_test.go
+++ b/pkg/api/controllers/script_controller_test.go
@@ -104,11 +104,7 @@ func TestPostScriptPreview(t *testing.T) {
 					res := controllers.ScriptResponse{}
 					internal.Decode(t, rsp.Body, &res)
 
-					cursor, err := store.GetTransactions(ctx, storage.NewTransactionsQuery(
-						0,
-						0,
-						&storage.TransactionsQueryFilters{},
-					))
+					cursor, err := store.GetTransactions(ctx, *storage.NewTransactionsQuery())
 					assert.NoError(t, err)
 					assert.Len(t, cursor.Data, 0)
 				})
@@ -125,10 +121,7 @@ func TestPostScriptPreview(t *testing.T) {
 					res := controllers.ScriptResponse{}
 					internal.Decode(t, rsp.Body, &res)
 
-					cursor, err := store.GetTransactions(ctx, storage.NewTransactionsQuery(
-						0,
-						0,
-						&storage.TransactionsQueryFilters{}))
+					cursor, err := store.GetTransactions(ctx, *storage.NewTransactionsQuery())
 					assert.NoError(t, err)
 					assert.Len(t, cursor.Data, 1)
 				})

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -88,13 +88,13 @@ func (l *Ledger) CommitPreview(ctx context.Context, txsData []core.TransactionDa
 	return l.processTx(ctx, txsData)
 }
 
-func (l *Ledger) GetTransactions(ctx context.Context, m ...storage.TxQueryModifier) (sharedapi.Cursor[core.Transaction], error) {
-	q := storage.NewTransactionsQuery(m)
+func (l *Ledger) GetTransactions(ctx context.Context, q storage.TransactionsQuery) (sharedapi.Cursor[core.Transaction], error) {
+
 	return l.store.GetTransactions(ctx, q)
 }
 
-func (l *Ledger) CountTransactions(ctx context.Context, m ...storage.TxQueryModifier) (uint64, error) {
-	q := storage.NewTransactionsQuery(m)
+func (l *Ledger) CountTransactions(ctx context.Context, q storage.TransactionsQuery) (uint64, error) {
+
 	return l.store.CountTransactions(ctx, q)
 }
 
@@ -151,14 +151,14 @@ func (l *Ledger) RevertTransaction(ctx context.Context, id uint64) (*core.Transa
 	return &result.GeneratedTransactions[0], nil
 }
 
-func (l *Ledger) CountAccounts(ctx context.Context, m ...storage.AccQueryModifier) (uint64, error) {
-	q := storage.NewAccountsQuery(m)
-	return l.store.CountAccounts(ctx, q)
+func (l *Ledger) CountAccounts(ctx context.Context, a storage.AccountsQuery) (uint64, error) {
+
+	return l.store.CountAccounts(ctx, a)
 }
 
-func (l *Ledger) GetAccounts(ctx context.Context, m ...storage.AccQueryModifier) (sharedapi.Cursor[core.Account], error) {
-	q := storage.NewAccountsQuery(m)
-	return l.store.GetAccounts(ctx, q)
+func (l *Ledger) GetAccounts(ctx context.Context, a storage.AccountsQuery) (sharedapi.Cursor[core.Account], error) {
+
+	return l.store.GetAccounts(ctx, a)
 }
 
 func (l *Ledger) GetAccount(ctx context.Context, address string) (core.Account, error) {

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -518,7 +518,7 @@ func TestGetTransactions(t *testing.T) {
 		_, err := l.Commit(context.Background(), []core.TransactionData{tx})
 		require.NoError(t, err)
 
-		res, err := l.GetTransactions(context.Background(), storage.NewTransactionsQuery(0, 0, nil))
+		res, err := l.GetTransactions(context.Background(), *storage.NewTransactionsQuery())
 		require.NoError(t, err)
 
 		assert.Equal(t, "test_get_transactions", res.Data[0].Postings[0].Destination)

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -518,7 +518,7 @@ func TestGetTransactions(t *testing.T) {
 		_, err := l.Commit(context.Background(), []core.TransactionData{tx})
 		require.NoError(t, err)
 
-		res, err := l.GetTransactions(context.Background())
+		res, err := l.GetTransactions(context.Background(), storage.NewTransactionsQuery(0, 0, nil))
 		require.NoError(t, err)
 
 		assert.Equal(t, "test_get_transactions", res.Data[0].Postings[0].Destination)
@@ -642,7 +642,7 @@ func BenchmarkGetAccount(b *testing.B) {
 func BenchmarkGetTransactions(b *testing.B) {
 	runOnLedger(func(l *Ledger) {
 		for i := 0; i < b.N; i++ {
-			_, err := l.GetTransactions(context.Background())
+			_, err := l.GetTransactions(context.Background(), storage.TransactionsQuery{})
 			require.NoError(b, err)
 		}
 	})

--- a/pkg/storage/accounts.go
+++ b/pkg/storage/accounts.go
@@ -4,7 +4,7 @@ type AccountsQuery struct {
 	Limit        uint
 	Offset       uint
 	AfterAddress string
-	Params       AccountsQueryFilters
+	Filters      AccountsQueryFilters
 }
 
 type AccountsQueryFilters struct {
@@ -75,25 +75,25 @@ func (a *AccountsQuery) WithAfterAddress(after string) *AccountsQuery {
 }
 
 func (a *AccountsQuery) WithAddressFilter(address string) *AccountsQuery {
-	a.Params.Address = address
+	a.Filters.Address = address
 
 	return a
 }
 
 func (a *AccountsQuery) WithBalanceFilter(balance string) *AccountsQuery {
-	a.Params.Balance = balance
+	a.Filters.Balance = balance
 
 	return a
 }
 
 func (a *AccountsQuery) WithBalanceOperatorFilter(balanceOperator BalanceOperator) *AccountsQuery {
-	a.Params.BalanceOperator = balanceOperator
+	a.Filters.BalanceOperator = balanceOperator
 
 	return a
 }
 
 func (a *AccountsQuery) WithMetadataFilter(metadata map[string]string) *AccountsQuery {
-	a.Params.Metadata = metadata
+	a.Filters.Metadata = metadata
 
 	return a
 }

--- a/pkg/storage/accounts.go
+++ b/pkg/storage/accounts.go
@@ -47,25 +47,53 @@ func NewBalanceOperator(s string) (BalanceOperator, bool) {
 	return BalanceOperator(s), true
 }
 
-func NewAccountsQuery(offset uint, limit uint, afterAddress string, filters *AccountsQueryFilters) AccountsQuery {
-	q := AccountsQuery{
+func NewAccountsQuery() *AccountsQuery {
+
+	return &AccountsQuery{
 		Limit: QueryDefaultLimit,
 	}
+}
 
-	// i'd rather use pointers and check if nil, but c.Query returns objects, so for now
-	// i'm testing zero values of object, please fix if you find something better
-
+func (a *AccountsQuery) WithLimit(limit uint) *AccountsQuery {
 	if limit != 0 {
-		q.Limit = limit
+		a.Limit = limit
 	}
 
-	q.AfterAddress = afterAddress
-	q.Offset = offset
+	return a
+}
 
-	q.Params.Address = filters.Address
-	q.Params.Balance = filters.Balance
-	q.Params.BalanceOperator = filters.BalanceOperator
-	q.Params.Metadata = filters.Metadata
+func (a *AccountsQuery) WithOffset(offset uint) *AccountsQuery {
+	a.Offset = offset
 
-	return q
+	return a
+}
+
+func (a *AccountsQuery) WithAfterAddress(after string) *AccountsQuery {
+	a.AfterAddress = after
+
+	return a
+}
+
+func (a *AccountsQuery) WithAddressFilter(address string) *AccountsQuery {
+	a.Params.Address = address
+
+	return a
+}
+
+func (a *AccountsQuery) WithBalanceFilter(balance string) *AccountsQuery {
+	a.Params.Balance = balance
+
+	return a
+}
+
+func (a *AccountsQuery) WithBalanceOperatorFilter(balanceOperator BalanceOperator) *AccountsQuery {
+	a.Params.BalanceOperator = balanceOperator
+
+	return a
+}
+
+func (a *AccountsQuery) WithMetadataFilter(metadata map[string]string) *AccountsQuery {
+	a.Params.Metadata = metadata
+
+	return a
 }

--- a/pkg/storage/sqlstorage/accounts.go
+++ b/pkg/storage/sqlstorage/accounts.go
@@ -22,10 +22,10 @@ func (s *Store) buildAccountsQuery(p storage.AccountsQuery) (*sqlbuilder.SelectB
 	sb.From(s.schema.Table("accounts"))
 
 	var (
-		address         = p.Params.Address
-		metadata        = p.Params.Metadata
-		balance         = p.Params.Balance
-		balanceOperator = p.Params.BalanceOperator
+		address         = p.Filters.Address
+		metadata        = p.Filters.Metadata
+		balance         = p.Filters.Balance
+		balanceOperator = p.Filters.BalanceOperator
 	)
 
 	if address != "" {

--- a/pkg/storage/sqlstorage/accounts.go
+++ b/pkg/storage/sqlstorage/accounts.go
@@ -16,24 +16,31 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *Store) buildAccountsQuery(p map[string]interface{}) (*sqlbuilder.SelectBuilder, AccPaginationToken) {
+func (s *Store) buildAccountsQuery(p storage.AccountsQuery) (*sqlbuilder.SelectBuilder, AccPaginationToken) {
 	sb := sqlbuilder.NewSelectBuilder()
 	t := AccPaginationToken{}
 	sb.From(s.schema.Table("accounts"))
 
-	if address, ok := p["address"]; ok && address.(string) != "" {
-		arg := sb.Args.Add("^" + address.(string) + "$")
+	var (
+		address         = p.Params.Address
+		metadata        = p.Params.Metadata
+		balance         = p.Params.Balance
+		balanceOperator = p.Params.BalanceOperator
+	)
+
+	if address != "" {
+		arg := sb.Args.Add("^" + address + "$")
 		switch s.Schema().Flavor() {
 		case sqlbuilder.PostgreSQL:
 			sb.Where("address ~* " + arg)
 		case sqlbuilder.SQLite:
 			sb.Where("address REGEXP " + arg)
 		}
-		t.AddressRegexpFilter = address.(string)
+		t.AddressRegexpFilter = address
 	}
 
-	if metadata, ok := p["metadata"]; ok {
-		for key, value := range metadata.(map[string]string) {
+	if len(metadata) > 0 {
+		for key, value := range metadata {
 			arg := sb.Args.Add(value)
 			// TODO: Need to find another way to specify the prefix since Table() methods does not make sense for functions and procedures
 			sb.Where(s.schema.Table(
@@ -41,21 +48,21 @@ func (s *Store) buildAccountsQuery(p map[string]interface{}) (*sqlbuilder.Select
 					SQLCustomFuncMetaCompare, arg, strings.ReplaceAll(key, ".", "', '")),
 			))
 		}
-		t.MetadataFilter = metadata.(map[string]string)
+		t.MetadataFilter = metadata
 	}
 
-	if balance, ok := p["balance"]; ok && balance.(string) != "" {
+	if balance != "" {
 
 		sb.Join(s.schema.Table("volumes"), "accounts.address = volumes.account")
 		balanceOperation := "volumes.input - volumes.output"
 
-		balanceValue, err := strconv.ParseInt(balance.(string), 10, 0)
+		balanceValue, err := strconv.ParseInt(balance, 10, 0)
 		if err != nil {
 			// parameter is validated in the controller for now
 			panic(errors.Wrap(err, "invalid balance parameter"))
 		}
 
-		if balanceOperator, ok := p["balance_operator"]; ok && balanceOperator != "" {
+		if balanceOperator != "" {
 			switch balanceOperator {
 			case storage.BalanceOperatorLte:
 				sb.Where(sb.LessEqualThan(balanceOperation, balanceValue))
@@ -86,7 +93,7 @@ func (s *Store) getAccounts(ctx context.Context, exec executor, q storage.Accoun
 		return sharedapi.Cursor[core.Account]{Data: accounts}, nil
 	}
 
-	sb, t := s.buildAccountsQuery(q.Params)
+	sb, t := s.buildAccountsQuery(q)
 	sb.Select("address", "metadata")
 	sb.OrderBy("address desc")
 

--- a/pkg/storage/sqlstorage/accounts_test.go
+++ b/pkg/storage/sqlstorage/accounts_test.go
@@ -31,8 +31,8 @@ func TestAccounts(t *testing.T) {
 	t.Run("success balance", func(t *testing.T) {
 		q := storage.AccountsQuery{
 			Limit: 10,
-			Params: map[string]interface{}{
-				"balance": "50",
+			Params: storage.AccountsQueryFilters{
+				Balance: "50",
 			},
 		}
 
@@ -43,13 +43,13 @@ func TestAccounts(t *testing.T) {
 	t.Run("panic invalid balance", func(t *testing.T) {
 		q := storage.AccountsQuery{
 			Limit: 10,
-			Params: map[string]interface{}{
-				"balance": "toto",
+			Params: storage.AccountsQueryFilters{
+				Balance: "TEST",
 			},
 		}
 
 		assert.PanicsWithError(
-			t, `invalid balance parameter: strconv.ParseInt: parsing "toto": invalid syntax`,
+			t, `invalid balance parameter: strconv.ParseInt: parsing "TEST": invalid syntax`,
 
 			func() {
 				_, _ = store.GetAccounts(context.Background(), q)
@@ -60,9 +60,9 @@ func TestAccounts(t *testing.T) {
 		assert.PanicsWithValue(t, "invalid balance_operator parameter", func() {
 			q := storage.AccountsQuery{
 				Limit: 10,
-				Params: map[string]interface{}{
-					"balance":          "50",
-					"balance_operator": "toto",
+				Params: storage.AccountsQueryFilters{
+					Balance:         "50",
+					BalanceOperator: "TEST",
 				},
 			}
 
@@ -73,9 +73,9 @@ func TestAccounts(t *testing.T) {
 	t.Run("success balance_operator", func(t *testing.T) {
 		q := storage.AccountsQuery{
 			Limit: 10,
-			Params: map[string]interface{}{
-				"balance":          "50",
-				"balance_operator": storage.BalanceOperator("gte"),
+			Params: storage.AccountsQueryFilters{
+				Balance:         "50",
+				BalanceOperator: storage.BalanceOperatorGte,
 			},
 		}
 

--- a/pkg/storage/sqlstorage/accounts_test.go
+++ b/pkg/storage/sqlstorage/accounts_test.go
@@ -31,7 +31,7 @@ func TestAccounts(t *testing.T) {
 	t.Run("success balance", func(t *testing.T) {
 		q := storage.AccountsQuery{
 			Limit: 10,
-			Params: storage.AccountsQueryFilters{
+			Filters: storage.AccountsQueryFilters{
 				Balance: "50",
 			},
 		}
@@ -43,7 +43,7 @@ func TestAccounts(t *testing.T) {
 	t.Run("panic invalid balance", func(t *testing.T) {
 		q := storage.AccountsQuery{
 			Limit: 10,
-			Params: storage.AccountsQueryFilters{
+			Filters: storage.AccountsQueryFilters{
 				Balance: "TEST",
 			},
 		}
@@ -60,7 +60,7 @@ func TestAccounts(t *testing.T) {
 		assert.PanicsWithValue(t, "invalid balance_operator parameter", func() {
 			q := storage.AccountsQuery{
 				Limit: 10,
-				Params: storage.AccountsQueryFilters{
+				Filters: storage.AccountsQueryFilters{
 					Balance:         "50",
 					BalanceOperator: "TEST",
 				},
@@ -73,7 +73,7 @@ func TestAccounts(t *testing.T) {
 	t.Run("success balance_operator", func(t *testing.T) {
 		q := storage.AccountsQuery{
 			Limit: 10,
-			Params: storage.AccountsQueryFilters{
+			Filters: storage.AccountsQueryFilters{
 				Balance:         "50",
 				BalanceOperator: storage.BalanceOperatorGte,
 			},

--- a/pkg/storage/sqlstorage/aggregations.go
+++ b/pkg/storage/sqlstorage/aggregations.go
@@ -10,10 +10,10 @@ import (
 	"github.com/numary/ledger/pkg/storage"
 )
 
-func (s *Store) countTransactions(ctx context.Context, exec executor, params map[string]interface{}) (uint64, error) {
+func (s *Store) countTransactions(ctx context.Context, exec executor, tq storage.TransactionsQuery) (uint64, error) {
 	var count uint64
 
-	sb, _ := s.buildTransactionsQuery(params)
+	sb, _ := s.buildTransactionsQuery(tq)
 	q, args := sb.BuildWithFlavor(s.schema.Flavor())
 	q = fmt.Sprintf(`SELECT count(*) FROM (%s) AS t`, q)
 	err := exec.QueryRowContext(ctx, q, args...).Scan(&count)
@@ -22,13 +22,13 @@ func (s *Store) countTransactions(ctx context.Context, exec executor, params map
 }
 
 func (s *Store) CountTransactions(ctx context.Context, q storage.TransactionsQuery) (uint64, error) {
-	return s.countTransactions(ctx, s.schema, q.Params)
+	return s.countTransactions(ctx, s.schema, q)
 }
 
-func (s *Store) countAccounts(ctx context.Context, exec executor, p map[string]interface{}) (uint64, error) {
+func (s *Store) countAccounts(ctx context.Context, exec executor, q storage.AccountsQuery) (uint64, error) {
 	var count uint64
 
-	sb, _ := s.buildAccountsQuery(p)
+	sb, _ := s.buildAccountsQuery(q)
 	sqlq, args := sb.Select("count(*)").BuildWithFlavor(s.schema.Flavor())
 	err := exec.QueryRowContext(ctx, sqlq, args...).Scan(&count)
 
@@ -36,7 +36,7 @@ func (s *Store) countAccounts(ctx context.Context, exec executor, p map[string]i
 }
 
 func (s *Store) CountAccounts(ctx context.Context, q storage.AccountsQuery) (uint64, error) {
-	return s.countAccounts(ctx, s.schema, q.Params)
+	return s.countAccounts(ctx, s.schema, q)
 }
 
 func (s *Store) getAssetsVolumes(ctx context.Context, exec executor, accountAddress string) (core.AssetsVolumes, error) {

--- a/pkg/storage/sqlstorage/store_test.go
+++ b/pkg/storage/sqlstorage/store_test.go
@@ -267,7 +267,7 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: storage.AccountsQueryFilters{
+		Filters: storage.AccountsQueryFilters{
 			Address: ".*der.*",
 		},
 	})
@@ -277,7 +277,7 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: storage.AccountsQueryFilters{
+		Filters: storage.AccountsQueryFilters{
 			Metadata: map[string]string{
 				"foo": "bar",
 			},
@@ -288,7 +288,7 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: storage.AccountsQueryFilters{
+		Filters: storage.AccountsQueryFilters{
 			Metadata: map[string]string{
 				"number": "3",
 			},
@@ -299,7 +299,7 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: storage.AccountsQueryFilters{
+		Filters: storage.AccountsQueryFilters{
 			Metadata: map[string]string{
 				"boolean": "true",
 			},
@@ -310,7 +310,7 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: storage.AccountsQueryFilters{
+		Filters: storage.AccountsQueryFilters{
 			Metadata: map[string]string{
 				"a.super.nested.key": "hello",
 			},
@@ -378,7 +378,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.EqualValues(t, 3, count)
 
 		count, err = store.CountTransactions(context.Background(), storage.TransactionsQuery{
-			Params: storage.TransactionsQueryFilters{
+			Filters: storage.TransactionsQueryFilters{
 				Account: "world",
 			},
 		})
@@ -387,7 +387,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.EqualValues(t, 2, count)
 
 		count, err = store.CountTransactions(context.Background(), storage.TransactionsQuery{
-			Params: storage.TransactionsQueryFilters{
+			Filters: storage.TransactionsQueryFilters{
 				Account:   "world",
 				StartTime: now.Add(-2 * time.Hour),
 				EndTime:   now.Add(-1 * time.Hour),
@@ -415,7 +415,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Equal(t, 1, cursor.PageSize)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: storage.TransactionsQueryFilters{
+			Filters: storage.TransactionsQueryFilters{
 				Account:   "world",
 				Reference: "tx1",
 			},
@@ -427,7 +427,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Len(t, cursor.Data, 1)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: storage.TransactionsQueryFilters{
+			Filters: storage.TransactionsQueryFilters{
 				Source: "central_bank",
 			},
 			Limit: 10,
@@ -438,7 +438,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Len(t, cursor.Data, 1)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: storage.TransactionsQueryFilters{
+			Filters: storage.TransactionsQueryFilters{
 				Destination: "users:1",
 			},
 			Limit: 10,
@@ -449,7 +449,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Len(t, cursor.Data, 1)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: storage.TransactionsQueryFilters{
+			Filters: storage.TransactionsQueryFilters{
 				StartTime: now.Add(-2 * time.Hour),
 				EndTime:   now.Add(-1 * time.Hour),
 			},

--- a/pkg/storage/sqlstorage/store_test.go
+++ b/pkg/storage/sqlstorage/store_test.go
@@ -267,8 +267,8 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: map[string]interface{}{
-			"address": ".*der.*",
+		Params: storage.AccountsQueryFilters{
+			Address: ".*der.*",
 		},
 	})
 	assert.NoError(t, err)
@@ -277,8 +277,8 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: map[string]interface{}{
-			"metadata": map[string]string{
+		Params: storage.AccountsQueryFilters{
+			Metadata: map[string]string{
 				"foo": "bar",
 			},
 		},
@@ -288,8 +288,8 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: map[string]interface{}{
-			"metadata": map[string]string{
+		Params: storage.AccountsQueryFilters{
+			Metadata: map[string]string{
 				"number": "3",
 			},
 		},
@@ -299,8 +299,8 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: map[string]interface{}{
-			"metadata": map[string]string{
+		Params: storage.AccountsQueryFilters{
+			Metadata: map[string]string{
 				"boolean": "true",
 			},
 		},
@@ -310,8 +310,8 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
-		Params: map[string]interface{}{
-			"metadata": map[string]string{
+		Params: storage.AccountsQueryFilters{
+			Metadata: map[string]string{
 				"a.super.nested.key": "hello",
 			},
 		},
@@ -378,8 +378,8 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.EqualValues(t, 3, count)
 
 		count, err = store.CountTransactions(context.Background(), storage.TransactionsQuery{
-			Params: map[string]interface{}{
-				"account": "world",
+			Params: storage.TransactionsQueryFilters{
+				Account: "world",
 			},
 		})
 		assert.NoError(t, err)
@@ -387,9 +387,10 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.EqualValues(t, 2, count)
 
 		count, err = store.CountTransactions(context.Background(), storage.TransactionsQuery{
-			Params: map[string]interface{}{
-				"start_time": now.Add(-2 * time.Hour),
-				"end_time":   now.Add(-1 * time.Hour),
+			Params: storage.TransactionsQueryFilters{
+				Account:   "world",
+				StartTime: now.Add(-2 * time.Hour),
+				EndTime:   now.Add(-1 * time.Hour),
 			},
 		})
 		assert.NoError(t, err)
@@ -414,9 +415,9 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Equal(t, 1, cursor.PageSize)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: map[string]interface{}{
-				"account":   "world",
-				"reference": "tx1",
+			Params: storage.TransactionsQueryFilters{
+				Account:   "world",
+				Reference: "tx1",
 			},
 			Limit: 1,
 		})
@@ -426,8 +427,8 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Len(t, cursor.Data, 1)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: map[string]interface{}{
-				"source": "central_bank",
+			Params: storage.TransactionsQueryFilters{
+				Source: "central_bank",
 			},
 			Limit: 10,
 		})
@@ -437,8 +438,8 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Len(t, cursor.Data, 1)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: map[string]interface{}{
-				"destination": "users:1",
+			Params: storage.TransactionsQueryFilters{
+				Destination: "users:1",
 			},
 			Limit: 10,
 		})
@@ -448,9 +449,9 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		assert.Len(t, cursor.Data, 1)
 
 		cursor, err = store.GetTransactions(context.Background(), storage.TransactionsQuery{
-			Params: map[string]interface{}{
-				"start_time": now.Add(-2 * time.Hour),
-				"end_time":   now.Add(-1 * time.Hour),
+			Params: storage.TransactionsQueryFilters{
+				StartTime: now.Add(-2 * time.Hour),
+				EndTime:   now.Add(-1 * time.Hour),
 			},
 			Limit: 10,
 		})

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -18,12 +18,12 @@ func (s *Store) buildTransactionsQuery(p storage.TransactionsQuery) (*sqlbuilder
 	t := TxsPaginationToken{}
 
 	var (
-		destination = p.Params.Destination
-		source      = p.Params.Source
-		account     = p.Params.Account
-		reference   = p.Params.Reference
-		startTime   = p.Params.StartTime
-		endTime     = p.Params.EndTime
+		destination = p.Filters.Destination
+		source      = p.Filters.Source
+		account     = p.Filters.Account
+		reference   = p.Filters.Reference
+		startTime   = p.Filters.StartTime
+		endTime     = p.Filters.EndTime
 	)
 
 	sb.Select("id", "timestamp", "reference", "metadata", "postings", "pre_commit_volumes", "post_commit_volumes")

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -13,38 +13,47 @@ import (
 	"github.com/numary/ledger/pkg/storage"
 )
 
-func (s *Store) buildTransactionsQuery(p map[string]interface{}) (*sqlbuilder.SelectBuilder, TxsPaginationToken) {
+func (s *Store) buildTransactionsQuery(p storage.TransactionsQuery) (*sqlbuilder.SelectBuilder, TxsPaginationToken) {
 	sb := sqlbuilder.NewSelectBuilder()
 	t := TxsPaginationToken{}
 
+	var (
+		destination = p.Params.Destination
+		source      = p.Params.Source
+		account     = p.Params.Account
+		reference   = p.Params.Reference
+		startTime   = p.Params.StartTime
+		endTime     = p.Params.EndTime
+	)
+
 	sb.Select("id", "timestamp", "reference", "metadata", "postings", "pre_commit_volumes", "post_commit_volumes")
 	sb.From(s.schema.Table("transactions"))
-	if account, ok := p["account"]; ok && account.(string) != "" {
-		arg := sb.Args.Add(account.(string))
+	if account != "" {
+		arg := sb.Args.Add(account)
 		sb.Where(s.schema.Table("use_account") + "(postings, " + arg + ")")
-		t.AccountFilter = account.(string)
+		t.AccountFilter = account
 	}
-	if source, ok := p["source"]; ok && source.(string) != "" {
-		arg := sb.Args.Add(source.(string))
+	if source != "" {
+		arg := sb.Args.Add(source)
 		sb.Where(s.schema.Table("use_account_as_source") + "(postings, " + arg + ")")
-		t.SourceFilter = source.(string)
+		t.SourceFilter = source
 	}
-	if destination, ok := p["destination"]; ok && destination.(string) != "" {
-		arg := sb.Args.Add(destination.(string))
+	if destination != "" {
+		arg := sb.Args.Add(destination)
 		sb.Where(s.schema.Table("use_account_as_destination") + "(postings, " + arg + ")")
-		t.DestinationFilter = destination.(string)
+		t.DestinationFilter = destination
 	}
-	if reference, ok := p["reference"]; ok && reference.(string) != "" {
-		sb.Where(sb.E("reference", reference.(string)))
-		t.ReferenceFilter = reference.(string)
+	if reference != "" {
+		sb.Where(sb.E("reference", reference))
+		t.ReferenceFilter = reference
 	}
-	if startTime, ok := p["start_time"]; ok && !startTime.(time.Time).IsZero() {
-		sb.Where(sb.GE("timestamp", startTime.(time.Time).UTC().Format(time.RFC3339)))
-		t.StartTime = startTime.(time.Time)
+	if !startTime.IsZero() {
+		sb.Where(sb.GE("timestamp", startTime.UTC().Format(time.RFC3339)))
+		t.StartTime = startTime
 	}
-	if endTime, ok := p["end_time"]; ok && !endTime.(time.Time).IsZero() {
-		sb.Where(sb.L("timestamp", endTime.(time.Time).UTC().Format(time.RFC3339)))
-		t.EndTime = endTime.(time.Time)
+	if !endTime.IsZero() {
+		sb.Where(sb.L("timestamp", endTime.UTC().Format(time.RFC3339)))
+		t.EndTime = endTime
 	}
 
 	return sb, t
@@ -57,7 +66,7 @@ func (s *Store) getTransactions(ctx context.Context, exec executor, q storage.Tr
 		return sharedapi.Cursor[core.Transaction]{Data: txs}, nil
 	}
 
-	sb, t := s.buildTransactionsQuery(q.Params)
+	sb, t := s.buildTransactionsQuery(q)
 	sb.OrderBy("id desc")
 	if q.AfterTxID > 0 {
 		sb.Where(sb.L("id", q.AfterTxID))

--- a/pkg/storage/transactions.go
+++ b/pkg/storage/transactions.go
@@ -7,7 +7,7 @@ import (
 type TransactionsQuery struct {
 	Limit     uint
 	AfterTxID uint64
-	Params    TransactionsQueryFilters
+	Filters   TransactionsQueryFilters
 }
 
 type TransactionsQueryFilters struct {
@@ -42,7 +42,7 @@ func (a *TransactionsQuery) WithAfterTxID(after uint64) *TransactionsQuery {
 
 func (a *TransactionsQuery) WithStartTimeFilter(start time.Time) *TransactionsQuery {
 	if !start.IsZero() {
-		a.Params.StartTime = start
+		a.Filters.StartTime = start
 	}
 
 	return a
@@ -50,32 +50,32 @@ func (a *TransactionsQuery) WithStartTimeFilter(start time.Time) *TransactionsQu
 
 func (a *TransactionsQuery) WithEndTimeFilter(end time.Time) *TransactionsQuery {
 	if !end.IsZero() {
-		a.Params.EndTime = end
+		a.Filters.EndTime = end
 	}
 
 	return a
 }
 
 func (a *TransactionsQuery) WithAccountFilter(account string) *TransactionsQuery {
-	a.Params.Account = account
+	a.Filters.Account = account
 
 	return a
 }
 
 func (a *TransactionsQuery) WithDestinationFilter(dest string) *TransactionsQuery {
-	a.Params.Destination = dest
+	a.Filters.Destination = dest
 
 	return a
 }
 
 func (a *TransactionsQuery) WithReferenceFilter(ref string) *TransactionsQuery {
-	a.Params.Reference = ref
+	a.Filters.Reference = ref
 
 	return a
 }
 
 func (a *TransactionsQuery) WithSourceFilter(source string) *TransactionsQuery {
-	a.Params.Source = source
+	a.Filters.Source = source
 
 	return a
 }

--- a/pkg/storage/transactions.go
+++ b/pkg/storage/transactions.go
@@ -4,7 +4,6 @@ import (
 	"time"
 )
 
-// please use the builder NewTransactionsQuery() if you're not sure what you're doing
 type TransactionsQuery struct {
 	Limit     uint
 	AfterTxID uint64
@@ -20,31 +19,63 @@ type TransactionsQueryFilters struct {
 	StartTime   time.Time
 }
 
-func NewTransactionsQuery(limit uint, afterTxID uint64, filters *TransactionsQueryFilters) TransactionsQuery {
-	q := TransactionsQuery{
+func NewTransactionsQuery() *TransactionsQuery {
+
+	return &TransactionsQuery{
 		Limit: QueryDefaultLimit,
 	}
+}
 
+func (a *TransactionsQuery) WithLimit(limit uint) *TransactionsQuery {
 	if limit != 0 {
-		q.Limit = limit
+		a.Limit = limit
 	}
 
-	q.AfterTxID = afterTxID
+	return a
+}
 
-	if filters != nil {
+func (a *TransactionsQuery) WithAfterTxID(after uint64) *TransactionsQuery {
+	a.AfterTxID = after
 
-		if !filters.StartTime.IsZero() {
-			q.Params.StartTime = filters.StartTime
-		}
-		if !filters.EndTime.IsZero() {
-			q.Params.EndTime = filters.EndTime
-		}
+	return a
+}
 
-		q.Params.Account = filters.Account
-		q.Params.Destination = filters.Destination
-		q.Params.Reference = filters.Reference
-		q.Params.Source = filters.Source
+func (a *TransactionsQuery) WithStartTimeFilter(start time.Time) *TransactionsQuery {
+	if !start.IsZero() {
+		a.Params.StartTime = start
 	}
 
-	return q
+	return a
+}
+
+func (a *TransactionsQuery) WithEndTimeFilter(end time.Time) *TransactionsQuery {
+	if !end.IsZero() {
+		a.Params.EndTime = end
+	}
+
+	return a
+}
+
+func (a *TransactionsQuery) WithAccountFilter(account string) *TransactionsQuery {
+	a.Params.Account = account
+
+	return a
+}
+
+func (a *TransactionsQuery) WithDestinationFilter(dest string) *TransactionsQuery {
+	a.Params.Destination = dest
+
+	return a
+}
+
+func (a *TransactionsQuery) WithReferenceFilter(ref string) *TransactionsQuery {
+	a.Params.Reference = ref
+
+	return a
+}
+
+func (a *TransactionsQuery) WithSourceFilter(source string) *TransactionsQuery {
+	a.Params.Source = source
+
+	return a
 }

--- a/pkg/storage/transactions.go
+++ b/pkg/storage/transactions.go
@@ -4,83 +4,47 @@ import (
 	"time"
 )
 
+// please use the builder NewTransactionsQuery() if you're not sure what you're doing
 type TransactionsQuery struct {
 	Limit     uint
 	AfterTxID uint64
-	Params    map[string]interface{}
+	Params    TransactionsQueryFilters
 }
 
-type TxQueryModifier func(*TransactionsQuery)
+type TransactionsQueryFilters struct {
+	Reference   string
+	Destination string
+	Source      string
+	Account     string
+	EndTime     time.Time
+	StartTime   time.Time
+}
 
-func NewTransactionsQuery(qms ...[]TxQueryModifier) TransactionsQuery {
+func NewTransactionsQuery(limit uint, afterTxID uint64, filters *TransactionsQueryFilters) TransactionsQuery {
 	q := TransactionsQuery{
-		Limit:  QueryDefaultLimit,
-		Params: map[string]interface{}{},
+		Limit: QueryDefaultLimit,
 	}
 
-	for _, m := range qms {
-		q.Apply(m)
+	if limit != 0 {
+		q.Limit = limit
+	}
+
+	q.AfterTxID = afterTxID
+
+	if filters != nil {
+
+		if !filters.StartTime.IsZero() {
+			q.Params.StartTime = filters.StartTime
+		}
+		if !filters.EndTime.IsZero() {
+			q.Params.EndTime = filters.EndTime
+		}
+
+		q.Params.Account = filters.Account
+		q.Params.Destination = filters.Destination
+		q.Params.Reference = filters.Reference
+		q.Params.Source = filters.Source
 	}
 
 	return q
-}
-
-func (q *TransactionsQuery) Apply(modifiers []TxQueryModifier) {
-	for _, m := range modifiers {
-		m(q)
-	}
-}
-
-func SetAfterTxID(v uint64) func(*TransactionsQuery) {
-	return func(q *TransactionsQuery) {
-		q.AfterTxID = v
-	}
-}
-
-func SetStartTime(v time.Time) func(*TransactionsQuery) {
-	return func(q *TransactionsQuery) {
-		if !v.IsZero() {
-			q.Params["start_time"] = v
-		}
-	}
-}
-
-func SetEndTime(v time.Time) func(*TransactionsQuery) {
-	return func(q *TransactionsQuery) {
-		if !v.IsZero() {
-			q.Params["end_time"] = v
-		}
-	}
-}
-
-func SetAccountFilter(v string) func(*TransactionsQuery) {
-	return func(q *TransactionsQuery) {
-		if v != "" {
-			q.Params["account"] = v
-		}
-	}
-}
-
-func SetSourceFilter(v string) func(*TransactionsQuery) {
-	return func(q *TransactionsQuery) {
-		if v != "" {
-			q.Params["source"] = v
-		}
-	}
-}
-
-func SetDestinationFilter(v string) func(*TransactionsQuery) {
-	return func(q *TransactionsQuery) {
-		if v != "" {
-			q.Params["destination"] = v
-		}
-	}
-}
-
-func SetReferenceFilter(v string) func(*TransactionsQuery) {
-	return func(q *TransactionsQuery) {
-		if v != "" {
-			q.Params["reference"] = v
-		}
-	}
 }


### PR DESCRIPTION
# Refactoring of the query building structures

As it was done, our query building didn't allow for multiple query parameters with the same name (even on different objects) being built easily. This PR aims to make the query building simpler, and more modular. It is done in two ways 
- All query building methods are removed, and a single builder (per db object) is in place to make the little checks and to fetch the necessary params
- No more map with string/interfaces. Since all of our params are known in advance, it makes more sense to use a defined struct, which is also easier to test.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Technical debt 

# How to test my feature ?

- [ ] `go test ./... -tags=json1`
- [ ] `docker compose up  ` 
Then, i did several tests using the API to list accounts and transactions, using some filters. I updated my db locally to test different cases, and always had an expected result. Please not that for these kind of tests to be useful, we should have a Local Testing Dataset common to everyone (publicly), and it could be used with Postman for example, to be able to check the API results directly. (It could also simply be a script of multiple cURL)
 
## What parts of the code are impacted ?
- api/controller
- storage

# Checklist:

- [ ] ~~My code follows the style guidelines of this project~~
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~New and existing unit tests pass locally with my changes~~