### PR TITLE
chore: remove duplicate go mod vendor

### DIFF
--- a/sdk/templates/go/Taskfile.yml.mustache
+++ b/sdk/templates/go/Taskfile.yml.mustache
@@ -27,5 +27,4 @@ tasks:
       - task: start-ledger
       - defer:
           task: stop-ledger
-      - go mod vendor
       - go test


### PR DESCRIPTION
# Title

Test already depends on vendor task, which already runs `go mod vendor`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring / Technical debt

## What parts of the code are impacted ?
Taskfile for Go SDK

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
