### PR TITLE
fix: Breaking change on page size.

### DIFF
--- a/pkg/storage/sqlstorage/accounts.go
+++ b/pkg/storage/sqlstorage/accounts.go
@@ -153,7 +153,7 @@ func (s *Store) getAccounts(ctx context.Context, exec executor, q storage.Accoun
 	}
 
 	return sharedapi.Cursor[core.Account]{
-		PageSize: len(accounts),
+		PageSize: int(q.Limit),
 		HasMore:  next != "",
 		Previous: previous,
 		Next:     next,

--- a/pkg/storage/sqlstorage/store_test.go
+++ b/pkg/storage/sqlstorage/store_test.go
@@ -273,7 +273,7 @@ func testGetAccounts(t *testing.T, store *sqlstorage.Store) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, accounts.Data, 2)
-	assert.Equal(t, 2, accounts.PageSize)
+	assert.Equal(t, 10, accounts.PageSize)
 
 	accounts, err = store.GetAccounts(context.Background(), storage.AccountsQuery{
 		Limit: 10,
@@ -433,7 +433,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 			Limit: 10,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 1, cursor.PageSize)
+		assert.Equal(t, 10, cursor.PageSize)
 		// Should get only the third transaction.
 		assert.Len(t, cursor.Data, 1)
 
@@ -444,7 +444,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 			Limit: 10,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 1, cursor.PageSize)
+		assert.Equal(t, 10, cursor.PageSize)
 		// Should get only the third transaction.
 		assert.Len(t, cursor.Data, 1)
 
@@ -456,7 +456,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 			Limit: 10,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 1, cursor.PageSize)
+		assert.Equal(t, 10, cursor.PageSize)
 		// Should get only tx2, as StartTime is inclusive and EndTime exclusive.
 		assert.Len(t, cursor.Data, 1)
 	})

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -140,7 +140,7 @@ func (s *Store) getTransactions(ctx context.Context, exec executor, q storage.Tr
 	}
 
 	return sharedapi.Cursor[core.Transaction]{
-		PageSize: len(txs),
+		PageSize: int(q.Limit),
 		HasMore:  next != "",
 		Previous: previous,
 		Next:     next,


### PR DESCRIPTION
# Fix breaking change on page size

A previous PR seems to have change the page size to return the number of the items instead of the limit.
For example, if the response of a transactions list contains 3 items, the page size should be 15 (default limit) but instead has a value of 3.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?

* pkg/storage

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
