### PR TITLE
feat: Add capability to pass a 'reference' when sending a script to the api.

### DIFF
--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -972,6 +972,10 @@ components:
     Script:
       type: object
       properties:
+        reference:
+          type: string
+          example: order_1234
+          description: Reference to attach to the generated transaction
         plain:
           type: string
           example: "vars {\naccount $user\n}\nsend [COIN 10] (\n\tsource = @world\n\tdestination = $user\n)\n"

--- a/pkg/core/script.go
+++ b/pkg/core/script.go
@@ -3,6 +3,7 @@ package core
 import "encoding/json"
 
 type Script struct {
-	Plain string                     `json:"plain"`
-	Vars  map[string]json.RawMessage `json:"vars" swaggertype:"object"`
+	Plain     string                     `json:"plain"`
+	Vars      map[string]json.RawMessage `json:"vars" swaggertype:"object"`
+	Reference string                     `json:"reference"`
 }

--- a/pkg/ledger/executor.go
+++ b/pkg/ledger/executor.go
@@ -95,8 +95,9 @@ func (l *Ledger) execute(ctx context.Context, script core.Script) (*core.Transac
 	}
 
 	t := &core.TransactionData{
-		Postings: m.Postings,
-		Metadata: m.GetTxMetaJson(),
+		Postings:  m.Postings,
+		Metadata:  m.GetTxMetaJson(),
+		Reference: script.Reference,
 	}
 
 	return t, nil

--- a/pkg/ledger/executor_test.go
+++ b/pkg/ledger/executor_test.go
@@ -350,3 +350,30 @@ func TestSetTxMeta(t *testing.T) {
 		}))
 	})
 }
+
+func TestScriptSetReference(t *testing.T) {
+	runOnLedger(func(l *Ledger) {
+		defer func(l *Ledger, ctx context.Context) {
+			require.NoError(t, l.Close(ctx))
+		}(l, context.Background())
+
+		plain := `send [USD/2 99] (
+			source=@world
+			destination=@user:001
+		)`
+
+		script := core.Script{
+			Plain:     plain,
+			Vars:      map[string]json.RawMessage{},
+			Reference: "tx_ref",
+		}
+
+		_, err := l.Execute(context.Background(), script)
+		require.NoError(t, err)
+
+		last, err := l.store.GetLastTransaction(context.Background())
+		require.NoError(t, err)
+
+		assert.Equal(t, script.Reference, last.Reference)
+	})
+}


### PR DESCRIPTION
# Add capability to define a reference when sending a script

The PR allow to define a reference when targetting the script endpoint.
The 'reference' property was added to the body of the request. If provided, the generated transaction will got this reference.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?
__Please describe the impacted parts of the code.__

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
