### PR TITLE
fix: GET /transactions: pagination with token always returns a "previous" when moving backward, even on the first page

### DIFF
--- a/pkg/api/controllers/pagination_test.go
+++ b/pkg/api/controllers/pagination_test.go
@@ -156,7 +156,6 @@ func getPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) func
 
 			accPages := numAcc / pageSize
 			additionalAccs := numAcc % pageSize
-			fmt.Printf("numAcc:%d accPages:%d addi:%d\n", numAcc, accPages, additionalAccs)
 
 			var paginationToken string
 			cursor := &sharedapi.Cursor[core.Account]{}

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -118,19 +118,8 @@ func (s *Store) getTransactions(ctx context.Context, exec executor, q storage.Tr
 
 	var previous, next string
 
-	// First page with transactions after
-	if q.AfterTxID == 0 && len(txs) > int(q.PageSize) {
-		txs = txs[:q.PageSize]
-		t.AfterTxID = txs[len(txs)-1].ID
-		raw, err := json.Marshal(t)
-		if err != nil {
-			return sharedapi.Cursor[core.Transaction]{}, s.error(err)
-		}
-		next = base64.RawURLEncoding.EncodeToString(raw)
-	}
-
 	// Page with transactions before
-	if q.AfterTxID > 0 && (len(txs) > 1 && txs[0].ID == q.AfterTxID) {
+	if q.AfterTxID > 0 && len(txs) > 1 && txs[0].ID == q.AfterTxID {
 		t.AfterTxID = txs[0].ID + uint64(q.PageSize)
 		txs = txs[1:]
 		raw, err := json.Marshal(t)
@@ -141,7 +130,7 @@ func (s *Store) getTransactions(ctx context.Context, exec executor, q storage.Tr
 	}
 
 	// Page with transactions after
-	if q.AfterTxID > 0 && len(txs) > int(q.PageSize) {
+	if len(txs) > int(q.PageSize) {
 		txs = txs[:q.PageSize]
 		t.AfterTxID = txs[len(txs)-1].ID
 		raw, err := json.Marshal(t)


### PR DESCRIPTION
# GET /transactions: pagination with token always returns a "previous" when moving backward, even on the first page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?
GET /transactions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
