### PR TITLE
feat: Add 'metadata' property on Script struct.

### DIFF
--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -976,6 +976,8 @@ components:
           type: string
           example: order_1234
           description: Reference to attach to the generated transaction
+        metadata:
+          $ref: '#/components/schemas/Metadata'
         plain:
           type: string
           example: "vars {\naccount $user\n}\nsend [COIN 10] (\n\tsource = @world\n\tdestination = $user\n)\n"

--- a/pkg/core/script.go
+++ b/pkg/core/script.go
@@ -6,4 +6,5 @@ type Script struct {
 	Plain     string                     `json:"plain"`
 	Vars      map[string]json.RawMessage `json:"vars" swaggertype:"object"`
 	Reference string                     `json:"reference"`
+	Metadata  Metadata                   `json:"metadata"`
 }

--- a/pkg/ledger/error.go
+++ b/pkg/ledger/error.go
@@ -104,6 +104,7 @@ const (
 	ScriptErrorInsufficientFund  = "INSUFFICIENT_FUND"
 	ScriptErrorCompilationFailed = "COMPILATION_FAILED"
 	ScriptErrorNoScript          = "NO_SCRIPT"
+	ScriptErrorMetadataOverride  = "METADATA_OVERRIDE"
 )
 
 type ScriptError struct {
@@ -123,8 +124,10 @@ func (e ScriptError) Is(err error) bool {
 	return e.Code == eerr.Code
 }
 
-func IsScriptError(err error) bool {
-	return errors.Is(err, &ScriptError{})
+func IsScriptErrorWithCode(err error, code string) bool {
+	return errors.Is(err, &ScriptError{
+		Code: code,
+	})
 }
 
 func NewScriptError(code string, message string) *ScriptError {

--- a/pkg/ledger/executor.go
+++ b/pkg/ledger/executor.go
@@ -94,9 +94,18 @@ func (l *Ledger) execute(ctx context.Context, script core.Script) (*core.Transac
 		}
 	}
 
+	metadata := m.GetTxMetaJson()
+	for k, v := range script.Metadata {
+		_, ok := metadata[k]
+		if ok {
+			return nil, NewScriptError(ScriptErrorMetadataOverride, "cannot override metadata from script")
+		}
+		metadata[k] = v
+	}
+
 	t := &core.TransactionData{
 		Postings:  m.Postings,
-		Metadata:  m.GetTxMetaJson(),
+		Metadata:  metadata,
 		Reference: script.Reference,
 	}
 

--- a/pkg/ledger/executor_test.go
+++ b/pkg/ledger/executor_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/numary/ledger/pkg/core"
-	machine "github.com/numary/machine/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -308,47 +307,80 @@ func TestMetadata(t *testing.T) {
 }
 
 func TestSetTxMeta(t *testing.T) {
-	runOnLedger(func(l *Ledger) {
-		defer func(l *Ledger, ctx context.Context) {
-			require.NoError(t, l.Close(ctx))
-		}(l, context.Background())
-
-		plain := `
-			vars {
-				account $user
-			}
-
-			set_tx_meta("test_meta", [COIN 10])
-
-			send [COIN 10] (
-				source = @world
-				destination = $user
-			)
-		`
-
-		script := core.Script{
-			Plain: plain,
-			Vars: map[string]json.RawMessage{
-				"user": json.RawMessage(`"user:042"`),
+	type testCase struct {
+		name              string
+		script            core.Script
+		expectedMetadata  core.Metadata
+		expectedErrorCode string
+	}
+	for _, tc := range []testCase{
+		{
+			name: "nominal",
+			script: core.Script{
+				Plain: `send [USD/2 99] (
+					source=@world
+					destination=@user:001
+				)`,
+				Metadata: core.Metadata{
+					"priority": json.RawMessage(`"low"`),
+				},
 			},
-		}
+			expectedMetadata: core.Metadata{
+				"priority": json.RawMessage(`"low"`),
+			},
+		},
+		{
+			name: "define metadata on script",
+			script: core.Script{
+				Plain: `
+                set_tx_meta("priority", "low")
+                send [COIN 10] (
+                    source = @world
+                    destination = @user:001
+				)`,
+			},
+			expectedMetadata: core.Metadata{
+				"priority": json.RawMessage(`{"type":"string","value":"low"}`),
+			},
+		},
+		{
+			name: "override metadata of script",
+			script: core.Script{
+				Plain: `
+				set_tx_meta("priority", "low")
 
-		_, err := l.Execute(context.Background(), script)
-		require.NoError(t, err)
+				send [USD/2 99] (
+					source=@world
+					destination=@user:001
+				)`,
+				Metadata: core.Metadata{
+					"priority": json.RawMessage(`"high"`),
+				},
+			},
+			expectedErrorCode: ScriptErrorMetadataOverride,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runOnLedger(func(l *Ledger) {
+				defer func(l *Ledger, ctx context.Context) {
+					require.NoError(t, l.Close(ctx))
+				}(l, context.Background())
 
-		assertBalance(t, l, "user:042", "COIN", 10)
+				_, err := l.Execute(context.Background(), tc.script)
 
-		last, err := l.store.GetLastTransaction(context.Background())
-		require.NoError(t, err)
+				if tc.expectedErrorCode != "" {
+					require.Error(t, err)
+					require.True(t, IsScriptErrorWithCode(err, tc.expectedErrorCode))
+				} else {
+					require.NoError(t, err)
+					last, err := l.store.GetLastTransaction(context.Background())
+					require.NoError(t, err)
 
-		value, err := machine.NewValueFromTypedJSON(last.Metadata["test_meta"])
-		require.NoError(t, err)
-
-		assert.True(t, machine.ValueEquals(*value, machine.Monetary{
-			Asset:  "COIN",
-			Amount: 10,
-		}))
-	})
+					assert.Equal(t, tc.expectedMetadata, last.Metadata)
+				}
+			})
+		})
+	}
 }
 
 func TestScriptSetReference(t *testing.T) {


### PR DESCRIPTION
# Add capability to define metadata on script endpoint 

Now the endpoint /script accept a property 'metadata' in the body.
The defined metadata will be appended to the generated transaction.
If a metadata is defined at numscript level AND at http level, the script will be reject with the error "METADATA_OVERRIDE".

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?
* pkg/ledger
* pkg/api

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
