### PR TITLE
fix(numscript): upgrade machine to v1.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgx/v4 v4.14.1
 	github.com/mattn/go-sqlite3 v1.14.9
-	github.com/numary/machine v1.1.1
+	github.com/numary/machine v1.1.2
 	github.com/ory/dockertest/v3 v3.8.1
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -697,6 +697,10 @@ github.com/numary/machine v0.0.0-20210702091459-23a82555adbf/go.mod h1:WAFvefAGY
 github.com/numary/machine v0.0.0-20210831114934-e54c99840e08/go.mod h1:KulcZIlMidEjXmuFSGNckmk0pKr4HFKFYy3bB+ksWSQ=
 github.com/numary/machine v1.1.1 h1:ESJJ7pCIzeMPS3V6esffIPBBiGXjKRdgB5aqfqND4FM=
 github.com/numary/machine v1.1.1/go.mod h1:lSdeCwegoylxgHOl6wBC9BgOo2N35ra53aTsRybmJsc=
+github.com/numary/machine v1.1.2-0.20220707224429-2a09b3f81249 h1:02EHCDlgU2aNV/B1r9jyUthlKaSHil28rPvvtAoVafM=
+github.com/numary/machine v1.1.2-0.20220707224429-2a09b3f81249/go.mod h1:lSdeCwegoylxgHOl6wBC9BgOo2N35ra53aTsRybmJsc=
+github.com/numary/machine v1.1.2 h1:MoPu4I2NvkM/V0CT8xNngsZrKrA3X5jA8Ge1ZCDamXA=
+github.com/numary/machine v1.1.2/go.mod h1:lSdeCwegoylxgHOl6wBC9BgOo2N35ra53aTsRybmJsc=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
# Upgrade Numscript Machine to v1.1.2 

Upgrade the Numscript Machine to v1.1.2 to bring this fix: https://github.com/numary/machine/pull/31

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?
The Numscript Machine

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
