### PR TITLE
feat: Add migration for pre/post commit volumes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/numary/ledger/cmd/internal"
 	"github.com/numary/ledger/pkg/redis"
-	// Add go migration
-	// Cannot set this line on storage as actually, it causes some circular dependencies
 	_ "github.com/numary/ledger/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/numary/ledger/cmd/internal"
 	"github.com/numary/ledger/pkg/redis"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	// Add go migration
 	// Cannot set this line on storage as actually, it causes some circular dependencies
 	_ "github.com/numary/ledger/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 const (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/numary/ledger/cmd/internal"
 	"github.com/numary/ledger/pkg/redis"
-
 	// Add go migration
 	// Cannot set this line on storage as actually, it causes some circular dependencies
 	_ "github.com/numary/ledger/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	// Add go migration
+	// Cannot set this line on storage as actually, it causes some circular dependencies
+	_ "github.com/numary/ledger/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	cloud.google.com/go v0.99.0 // indirect
 	cloud.google.com/go/storage v1.18.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/ThreeDotsLabs/watermill-http v1.1.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/lib/pq v1.10.2
 	github.com/numary/go-libs v0.0.0-20220609103351-69aecd5d4097
+	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/uptrace/opentelemetry-go-extra/otellogrus v0.1.12
 	github.com/xdg-go/scram v1.1.0
 	gopkg.in/segmentio/analytics-go.v3 v3.1.0
@@ -55,7 +56,6 @@ require (
 	cloud.google.com/go v0.99.0 // indirect
 	cloud.google.com/go/storage v1.18.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/ThreeDotsLabs/watermill-http v1.1.4 // indirect
@@ -136,7 +136,6 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	github.com/spf13/afero v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,6 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7O
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
-github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -697,10 +695,6 @@ github.com/numary/ledger v0.0.0-20210702172952-a5bd30e551d0/go.mod h1:u2K28z9TDY
 github.com/numary/ledger v0.0.0-20211227131550-dc7b78f85b5b/go.mod h1:uovuDsK7Gs7duqKQ9PgaFulJnPTDftGdR/n3rBRzNIs=
 github.com/numary/machine v0.0.0-20210702091459-23a82555adbf/go.mod h1:WAFvefAGYNjdDmPtDoZ305F58QDtUJyB0QWN3vzSZao=
 github.com/numary/machine v0.0.0-20210831114934-e54c99840e08/go.mod h1:KulcZIlMidEjXmuFSGNckmk0pKr4HFKFYy3bB+ksWSQ=
-github.com/numary/machine v1.1.1 h1:ESJJ7pCIzeMPS3V6esffIPBBiGXjKRdgB5aqfqND4FM=
-github.com/numary/machine v1.1.1/go.mod h1:lSdeCwegoylxgHOl6wBC9BgOo2N35ra53aTsRybmJsc=
-github.com/numary/machine v1.1.2-0.20220707224429-2a09b3f81249 h1:02EHCDlgU2aNV/B1r9jyUthlKaSHil28rPvvtAoVafM=
-github.com/numary/machine v1.1.2-0.20220707224429-2a09b3f81249/go.mod h1:lSdeCwegoylxgHOl6wBC9BgOo2N35ra53aTsRybmJsc=
 github.com/numary/machine v1.1.2 h1:MoPu4I2NvkM/V0CT8xNngsZrKrA3X5jA8Ge1ZCDamXA=
 github.com/numary/machine v1.1.2/go.mod h1:lSdeCwegoylxgHOl6wBC9BgOo2N35ra53aTsRybmJsc=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7O
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=

--- a/pkg/core/volumes.go
+++ b/pkg/core/volumes.go
@@ -43,6 +43,52 @@ func (v AssetsVolumes) Balances() AssetsBalances {
 
 type AccountsAssetsVolumes map[string]AssetsVolumes
 
+func (a AccountsAssetsVolumes) GetVolumes(account, asset string) Volumes {
+	if assetsVolumes, ok := a[account]; !ok {
+		return Volumes{}
+	} else {
+		return assetsVolumes[asset]
+	}
+}
+
+func (a AccountsAssetsVolumes) SetVolumes(account, asset string, volumes Volumes) {
+	if assetsVolumes, ok := a[account]; !ok {
+		a[account] = map[string]Volumes{
+			asset: volumes,
+		}
+	} else {
+		assetsVolumes[asset] = volumes
+	}
+}
+
+func (a AccountsAssetsVolumes) AddInput(account, asset string, input int64) {
+	if assetsVolumes, ok := a[account]; !ok {
+		a[account] = map[string]Volumes{
+			asset: {
+				Input: input,
+			},
+		}
+	} else {
+		volumes := assetsVolumes[asset]
+		volumes.Input += input
+		assetsVolumes[asset] = volumes
+	}
+}
+
+func (a AccountsAssetsVolumes) AddOutput(account, asset string, output int64) {
+	if assetsVolumes, ok := a[account]; !ok {
+		a[account] = map[string]Volumes{
+			asset: {
+				Output: output,
+			},
+		}
+	} else {
+		volumes := assetsVolumes[asset]
+		volumes.Output += output
+		assetsVolumes[asset] = volumes
+	}
+}
+
 // Scan - Implement the database/sql scanner interface
 func (a *AccountsAssetsVolumes) Scan(value interface{}) error {
 	if value == nil {

--- a/pkg/core/volumes.go
+++ b/pkg/core/volumes.go
@@ -43,15 +43,6 @@ func (v AssetsVolumes) Balances() AssetsBalances {
 
 type AccountsAssetsVolumes map[string]AssetsVolumes
 
-func (a AccountsAssetsVolumes) EnsureAccountExists(accounts ...string) {
-	for _, account := range accounts {
-		_, ok := a[account]
-		if !ok {
-			a[account] = AssetsVolumes{}
-		}
-	}
-}
-
 func (a AccountsAssetsVolumes) GetVolumes(account, asset string) Volumes {
 	if assetsVolumes, ok := a[account]; !ok {
 		return Volumes{}

--- a/pkg/core/volumes.go
+++ b/pkg/core/volumes.go
@@ -43,6 +43,15 @@ func (v AssetsVolumes) Balances() AssetsBalances {
 
 type AccountsAssetsVolumes map[string]AssetsVolumes
 
+func (a AccountsAssetsVolumes) EnsureAccountExists(accounts ...string) {
+	for _, account := range accounts {
+		_, ok := a[account]
+		if !ok {
+			a[account] = AssetsVolumes{}
+		}
+	}
+}
+
 func (a AccountsAssetsVolumes) GetVolumes(account, asset string) Volumes {
 	if assetsVolumes, ok := a[account]; !ok {
 		return Volumes{}
@@ -87,6 +96,11 @@ func (a AccountsAssetsVolumes) AddOutput(account, asset string, output int64) {
 		volumes.Output += output
 		assetsVolumes[asset] = volumes
 	}
+}
+
+func (a AccountsAssetsVolumes) HasAccount(account string) bool {
+	_, ok := a[account]
+	return ok
 }
 
 // Scan - Implement the database/sql scanner interface

--- a/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any.go
+++ b/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any.go
@@ -1,0 +1,110 @@
+package add_pre_post_volumes
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/huandu/go-sqlbuilder"
+	"github.com/numary/ledger/pkg/core"
+	"github.com/numary/ledger/pkg/storage/sqlstorage"
+)
+
+func init() {
+	sqlstorage.RegisterGoMigration(Upgrade)
+}
+
+type Transaction struct {
+	ID       uint64        `json:"txid"`
+	Postings core.Postings `json:"postings"`
+}
+
+func Upgrade(ctx context.Context, schema sqlstorage.Schema, sqlTx *sql.Tx) error {
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.From(schema.Table("log"))
+	sb.Select("data")
+	sb.Where(sb.E("type", core.NewTransactionType))
+	sb.OrderBy("id")
+	sb.Asc()
+
+	sqlq, args := sb.BuildWithFlavor(schema.Flavor())
+	rows, err := sqlTx.QueryContext(ctx, sqlq, args...)
+	if err != nil {
+		return err
+	}
+
+	aggregatedVolumes := core.AccountsAssetsVolumes{}
+	for rows.Next() {
+		var data string
+		err := rows.Scan(&data)
+		if err != nil {
+			return err
+		}
+
+		var tx Transaction
+		err = json.Unmarshal([]byte(data), &tx)
+		if err != nil {
+			return err
+		}
+
+		preCommitVolumes := core.AccountsAssetsVolumes{}
+		postCommitVolumes := core.AccountsAssetsVolumes{}
+		for _, posting := range tx.Postings {
+			if _, ok := preCommitVolumes[posting.Source]; !ok {
+				preCommitVolumes[posting.Source] = core.AssetsVolumes{}
+			}
+			if _, ok := preCommitVolumes[posting.Destination]; !ok {
+				preCommitVolumes[posting.Destination] = core.AssetsVolumes{}
+			}
+			preCommitVolumes[posting.Source][posting.Asset] = aggregatedVolumes.GetVolumes(posting.Source, posting.Asset)
+			preCommitVolumes[posting.Destination][posting.Asset] = aggregatedVolumes.GetVolumes(posting.Destination, posting.Asset)
+
+			if _, ok := postCommitVolumes[posting.Source]; !ok {
+				postCommitVolumes.SetVolumes(posting.Source, posting.Asset,
+					preCommitVolumes.GetVolumes(posting.Source, posting.Asset))
+
+			}
+			if _, ok := postCommitVolumes[posting.Destination]; !ok {
+				postCommitVolumes.SetVolumes(posting.Destination, posting.Asset,
+					preCommitVolumes.GetVolumes(posting.Destination, posting.Asset))
+			}
+
+			postCommitVolumes.AddOutput(posting.Source, posting.Asset, posting.Amount)
+			postCommitVolumes.AddInput(posting.Destination, posting.Asset, posting.Amount)
+		}
+
+		for account, accountVolumes := range postCommitVolumes {
+			for asset, volumes := range accountVolumes {
+				aggregatedVolumes.SetVolumes(account, asset, volumes)
+			}
+		}
+
+		preCommitVolumesData, err := json.Marshal(preCommitVolumes)
+		if err != nil {
+			return err
+		}
+
+		postCommitVolumesData, err := json.Marshal(postCommitVolumes)
+		if err != nil {
+			return err
+		}
+
+		ub := sqlbuilder.NewUpdateBuilder()
+		ub.Update(schema.Table("transactions"))
+		ub.Set(
+			ub.Assign("pre_commit_volumes", preCommitVolumesData),
+			ub.Assign("post_commit_volumes", postCommitVolumesData),
+		)
+		ub.Where(ub.E("id", tx.ID))
+		sqlq, args := ub.Build()
+
+		fmt.Println(sqlq, args)
+		_, err = sqlTx.ExecContext(ctx, sqlq, args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any.go
+++ b/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any.go
@@ -55,7 +55,6 @@ func Upgrade(ctx context.Context, schema sqlstorage.Schema, sqlTx *sql.Tx) error
 		preCommitVolumes := core.AccountsAssetsVolumes{}
 		postCommitVolumes := core.AccountsAssetsVolumes{}
 		for _, posting := range tx.Postings {
-			preCommitVolumes.EnsureAccountExists(posting.Source, posting.Destination)
 
 			preCommitVolumes.SetVolumes(posting.Source, posting.Asset,
 				aggregatedVolumes.GetVolumes(posting.Source, posting.Asset))

--- a/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any_test.go
+++ b/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any_test.go
@@ -1,0 +1,246 @@
+package add_pre_post_volumes_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/numary/ledger/pkg/core"
+	"github.com/numary/ledger/pkg/ledgertesting"
+	"github.com/numary/ledger/pkg/storage"
+	"github.com/numary/ledger/pkg/storage/sqlstorage"
+	add_pre_post_volumes "github.com/numary/ledger/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type testCase struct {
+	postings                  core.Postings
+	expectedPreCommitVolumes  core.AccountsAssetsVolumes
+	expectedPostCommitVolumes core.AccountsAssetsVolumes
+}
+
+var testCases = []testCase{
+	{
+		postings: core.Postings{
+			{
+				Source:      "world",
+				Destination: "bank",
+				Amount:      100,
+				Asset:       "USD",
+			},
+		},
+		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
+			"world": {
+				"USD": {},
+			},
+			"bank": {
+				"USD": {},
+			},
+		},
+		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
+			"world": {
+				"USD": {
+					Output: 100,
+				},
+			},
+			"bank": {
+				"USD": {
+					Input: 100,
+				},
+			},
+		},
+	},
+	{
+		postings: core.Postings{
+			{
+				Source:      "world",
+				Destination: "bank2",
+				Amount:      100,
+				Asset:       "USD",
+			},
+		},
+		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
+			"world": {
+				"USD": {
+					Output: 100,
+				},
+			},
+			"bank2": {
+				"USD": {},
+			},
+		},
+		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
+			"world": {
+				"USD": {
+					Output: 200,
+				},
+			},
+			"bank2": {
+				"USD": {
+					Input: 100,
+				},
+			},
+		},
+	},
+	{
+		postings: core.Postings{
+			{
+				Source:      "world",
+				Destination: "bank",
+				Amount:      100,
+				Asset:       "USD",
+			},
+			{
+				Source:      "world",
+				Destination: "bank2",
+				Amount:      100,
+				Asset:       "USD",
+			},
+		},
+		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
+			"world": {
+				"USD": {
+					Output: 200,
+				},
+			},
+			"bank": {
+				"USD": {
+					Input: 100,
+				},
+			},
+			"bank2": {
+				"USD": {
+					Input: 100,
+				},
+			},
+		},
+		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
+			"world": {
+				"USD": {
+					Output: 400,
+				},
+			},
+			"bank2": {
+				"USD": {
+					Input: 200,
+				},
+			},
+			"bank": {
+				"USD": {
+					Input: 200,
+				},
+			},
+		},
+	},
+	{
+		postings: core.Postings{
+			{
+				Source:      "bank",
+				Destination: "user:1",
+				Amount:      10,
+				Asset:       "USD",
+			},
+			{
+				Source:      "bank",
+				Destination: "user:2",
+				Amount:      90,
+				Asset:       "USDT",
+			},
+		},
+		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
+			"bank": {
+				"USD": {
+					Input: 200,
+				},
+				"USDT": {},
+			},
+			"user:1": {
+				"USD": {},
+			},
+			"user:2": {
+				"USDT": {},
+			},
+		},
+		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
+			"bank": {
+				"USD": {
+					Input:  200,
+					Output: 10,
+				},
+				"USDT": {
+					Output: 90,
+				},
+			},
+			"user:1": {
+				"USD": {
+					Input: 10,
+				},
+			},
+			"user:2": {
+				"USDT": {
+					Input: 90,
+				},
+			},
+		},
+	},
+}
+
+func TestMigrate9(t *testing.T) {
+	driver, closeFunc, err := ledgertesting.StorageDriver()
+	require.NoError(t, err)
+	defer closeFunc()
+
+	require.NoError(t, driver.Initialize(context.Background()))
+	store, _, err := driver.GetStore(context.Background(), uuid.New(), true)
+	require.NoError(t, err)
+
+	schema := store.(*sqlstorage.Store).Schema()
+
+	migrations, err := sqlstorage.CollectMigrationFiles(sqlstorage.MigrationsFS)
+	require.NoError(t, err)
+
+	modified, err := sqlstorage.Migrate(context.Background(), schema, migrations[0:9]...)
+	require.NoError(t, err)
+	require.True(t, modified)
+
+	now := time.Now()
+	for i, tc := range testCases {
+		txData, err := json.Marshal(struct {
+			add_pre_post_volumes.Transaction
+			Date time.Time `json:"timestamp"`
+		}{
+			Transaction: add_pre_post_volumes.Transaction{
+				ID:       uint64(i),
+				Postings: tc.postings,
+			},
+			Date: now,
+		})
+		require.NoError(t, err)
+
+		_, err = schema.ExecContext(context.Background(),
+			`INSERT INTO log (id, data, type, date) VALUES (?, ?, ?, ?)`,
+			i, string(txData), core.NewTransactionType, now)
+		require.NoError(t, err)
+	}
+
+	txs, err := store.GetTransactions(context.Background(), *storage.NewTransactionsQuery())
+	require.NoError(t, err)
+	require.Len(t, txs.Data, len(testCases))
+
+	sqlTx, err := schema.BeginTx(context.Background(), &sql.TxOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, add_pre_post_volumes.Upgrade(context.Background(), schema, sqlTx))
+	require.NoError(t, sqlTx.Commit())
+
+	for i, tc := range testCases {
+		tx, err := store.GetTransaction(context.Background(), uint64(i))
+		require.NoError(t, err)
+		require.Equal(t, tc.expectedPreCommitVolumes, tx.PreCommitVolumes)
+		require.Equal(t, tc.expectedPostCommitVolumes, tx.PostCommitVolumes)
+	}
+
+}

--- a/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any_test.go
+++ b/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/ledger/pkg/core"
 	"github.com/numary/ledger/pkg/ledgertesting"
 	"github.com/numary/ledger/pkg/storage"
@@ -220,9 +221,13 @@ func TestMigrate9(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = schema.ExecContext(context.Background(),
-			`INSERT INTO log (id, data, type, date) VALUES (?, ?, ?, ?)`,
-			i, string(txData), core.NewTransactionType, now)
+		ib := sqlbuilder.NewInsertBuilder()
+		ib.InsertInto(schema.Table("log"))
+		ib.Cols("id", "data", "type", "date")
+		ib.Values(i, string(txData), core.NewTransactionType, now)
+		sqlq, args := ib.BuildWithFlavor(schema.Flavor())
+
+		_, err = schema.ExecContext(context.Background(), sqlq, args...)
 		require.NoError(t, err)
 	}
 

--- a/pkg/storage/sqlstorage/register.go
+++ b/pkg/storage/sqlstorage/register.go
@@ -18,7 +18,6 @@ func RegisterGoMigration(fn MigrationFunc) {
 }
 
 func RegisterGoMigrationFromFilename(filename string, fn MigrationFunc) {
-
 	rest, goFile := filepath.Split(filename)
 	directory := filepath.Base(rest)
 


### PR DESCRIPTION
# Add migration for pre/post commit volumes

This PR add a migration to generate 'pre_commit_volumes' and 'post_commit_volumes' columns for 'transactions' table.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?
* pkg/storage/sqlstorage 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
