### PR TITLE
feat: Make logs store only the payload of the write action

### DIFF
--- a/pkg/core/log.go
+++ b/pkg/core/log.go
@@ -11,27 +11,6 @@ import (
 const SetMetadataType = "SET_METADATA"
 const NewTransactionType = "NEW_TRANSACTION"
 
-type LoggedTX Transaction
-
-func (m LoggedTX) MarshalJSON() ([]byte, error) {
-	metadata := make(map[string]interface{})
-	for k, v := range m.Metadata {
-		var i interface{}
-		err := json.Unmarshal(v, &i)
-		if err != nil {
-			return nil, err
-		}
-		metadata[k] = i
-	}
-	return json.Marshal(struct {
-		Transaction
-		Metadata map[string]interface{} `json:"metadata"`
-	}{
-		Transaction: Transaction(m),
-		Metadata:    metadata,
-	})
-}
-
 type Log struct {
 	ID   uint64      `json:"id"`
 	Type string      `json:"type"`
@@ -41,7 +20,6 @@ type Log struct {
 }
 
 func NewTransactionLogWithDate(previousLog *Log, tx Transaction, time time.Time) Log {
-
 	id := uint64(0)
 	if previousLog != nil {
 		id = previousLog.ID + 1
@@ -50,7 +28,7 @@ func NewTransactionLogWithDate(previousLog *Log, tx Transaction, time time.Time)
 		ID:   id,
 		Type: NewTransactionType,
 		Date: time,
-		Data: LoggedTX(tx),
+		Data: tx.payload(),
 	}
 	l.Hash = Hash(previousLog, &l)
 	return l

--- a/pkg/core/transaction.go
+++ b/pkg/core/transaction.go
@@ -38,6 +38,31 @@ type Transaction struct {
 	PostCommitVolumes AccountsAssetsVolumes `json:"postCommitVolumes,omitempty"` // Keep omitempty to keep consistent hash
 }
 
+func (t Transaction) payload() any {
+	metadata := make(map[string]interface{})
+	for k, v := range t.Metadata {
+		var i interface{}
+		err := json.Unmarshal(v, &i)
+		if err != nil {
+			panic(err)
+		}
+		metadata[k] = i
+	}
+	return struct {
+		Postings  Postings               `json:"postings"`
+		Reference string                 `json:"reference"`
+		Metadata  map[string]interface{} `json:"metadata"`
+		ID        uint64                 `json:"txid"`
+		Timestamp string                 `json:"timestamp"`
+	}{
+		Postings:  t.Postings,
+		Reference: t.Reference,
+		Metadata:  metadata,
+		ID:        t.ID,
+		Timestamp: t.Timestamp,
+	}
+}
+
 func (t *Transaction) AppendPosting(p Posting) {
 	t.Postings = append(t.Postings, p)
 }

--- a/pkg/storage/sqlstorage/migrates/11-clean-logs/any_test.go
+++ b/pkg/storage/sqlstorage/migrates/11-clean-logs/any_test.go
@@ -1,0 +1,90 @@
+package clean_logs_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/huandu/go-sqlbuilder"
+	"github.com/numary/ledger/pkg/core"
+	"github.com/numary/ledger/pkg/ledgertesting"
+	"github.com/numary/ledger/pkg/storage/sqlstorage"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrate(t *testing.T) {
+	driver, closeFunc, err := ledgertesting.StorageDriver()
+	require.NoError(t, err)
+	defer closeFunc()
+
+	require.NoError(t, driver.Initialize(context.Background()))
+	store, _, err := driver.GetStore(context.Background(), uuid.New(), true)
+	require.NoError(t, err)
+
+	schema := store.(*sqlstorage.Store).Schema()
+
+	migrations, err := sqlstorage.CollectMigrationFiles(sqlstorage.MigrationsFS)
+	require.NoError(t, err)
+
+	modified, err := sqlstorage.Migrate(context.Background(), schema, migrations[0:11]...)
+	require.NoError(t, err)
+	require.True(t, modified)
+
+	sqlq, args := sqlbuilder.NewInsertBuilder().
+		InsertInto(schema.Table("log")).
+		Cols("id", "type", "hash", "date", "data").
+		Values("0", core.NewTransactionType, "", time.Now(), `{
+			"txid": 0,
+			"postings": [],
+			"reference": "tx1"
+		}`).
+		Values("1", core.NewTransactionType, "", time.Now(), `{
+			"txid": 1,
+			"postings": [],
+			"preCommitVolumes": {},
+			"postCommitVolumes": {},
+			"reference": "tx2"
+		}`).
+		BuildWithFlavor(schema.Flavor())
+
+	_, err = schema.ExecContext(context.Background(), sqlq, args...)
+	require.NoError(t, err)
+
+	modified, err = sqlstorage.Migrate(context.Background(), schema, migrations[11])
+	require.NoError(t, err)
+	require.True(t, modified)
+
+	sqlq, args = sqlbuilder.NewSelectBuilder().
+		Select("data").
+		From(schema.Table("log")).
+		BuildWithFlavor(schema.Flavor())
+
+	rows, err := schema.QueryContext(context.Background(), sqlq, args...)
+	require.NoError(t, err)
+
+	require.True(t, rows.Next())
+	var dataStr string
+	require.NoError(t, rows.Scan(&dataStr))
+
+	data := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(dataStr), &data))
+
+	require.Equal(t, map[string]any{
+		"txid":      float64(0),
+		"postings":  []interface{}{},
+		"reference": "tx1",
+	}, data)
+
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&dataStr))
+	require.NoError(t, json.Unmarshal([]byte(dataStr), &data))
+
+	require.Equal(t, map[string]any{
+		"txid":      float64(1),
+		"postings":  []interface{}{},
+		"reference": "tx2",
+	}, data)
+
+}

--- a/pkg/storage/sqlstorage/migrates/11-clean-logs/postgres.sql
+++ b/pkg/storage/sqlstorage/migrates/11-clean-logs/postgres.sql
@@ -1,0 +1,2 @@
+--statement
+update "VAR_LEDGER_NAME".log set data = data - 'preCommitVolumes' - 'postCommitVolumes';

--- a/pkg/storage/sqlstorage/migrates/11-clean-logs/sqlite.sql
+++ b/pkg/storage/sqlstorage/migrates/11-clean-logs/sqlite.sql
@@ -1,0 +1,3 @@
+--statement
+update log set data = json_remove(json_remove(data, '$.preCommitVolumes'), '$.postCommitVolumes');
+


### PR DESCRIPTION
# Make logs store only the payload of the write action

Previously, the logs was embed the full transaction (in case of a commit).
So when we added 'preCommitVolumes' and 'postCommitVolumes' properties, these was been embedded whereas these are not required (can be recalculated).
This PR fix the problem for futures transactions, and add a migration to fix corrupted logs.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt