### PR TITLE
fix: set logs as UTC when reading from database

### DIFF
--- a/pkg/storage/sqlstorage/log.go
+++ b/pkg/storage/sqlstorage/log.go
@@ -114,6 +114,7 @@ func (s *Store) lastLog(ctx context.Context, exec executor) (*core.Log, error) {
 	if err != nil {
 		return nil, err
 	}
+	l.Date = l.Date.UTC()
 
 	return &l, nil
 }
@@ -153,6 +154,7 @@ func (s *Store) logs(ctx context.Context, exec executor) ([]core.Log, error) {
 			}
 			return nil, err
 		}
+		l.Date = l.Date.UTC()
 
 		l.Data, err = core.HydrateLog(l.Type, data.String)
 		if err != nil {


### PR DESCRIPTION
# Fix logs reading

When reading date from database, the sql driver set the local to the system local.
And when we compute the hash of a log (before database insertion), we are using the date as UTC. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt
