### PR TITLE
fix: swagger tx timestamp

### DIFF
--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -1182,6 +1182,9 @@ components:
     Transaction:
       type: object
       properties:
+        timestamp:
+          type: string
+          format: date-time
         postings:
           type: array
           items:


### PR DESCRIPTION
# Fix swagger

Fix missing transaction timestamp in swagger specification.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt
