### PR TITLE
feat: Change the order of UNSUFFICIENT_FUNDS and CONFLICT errors

### DIFF
--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -66,12 +66,7 @@ func (l *Ledger) Commit(ctx context.Context, txsData []core.TransactionData) (*C
 	}
 
 	if err = l.store.AppendLog(ctx, result.GeneratedLogs...); err != nil {
-		switch {
-		case storage.IsErrorCode(err, storage.ConstraintFailed):
-			return nil, NewConflictError()
-		default:
-			return nil, err
-		}
+		return nil, err
 	}
 
 	l.monitor.CommittedTransactions(ctx, l.store.Name(), result)

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -218,10 +218,10 @@ func TestTransactionBatchWithConflictingReference(t *testing.T) {
 			{
 				Postings: []core.Posting{
 					{
-						Source:      "world",
-						Destination: "player",
+						Source:      "player",
+						Destination: "player2",
 						Asset:       "GEM",
-						Amount:      int64(100),
+						Amount:      int64(1000), // Should trigger an insufficient fund error but the conflict error has precedence over it
 					},
 				},
 				Reference: "ref1",

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -191,9 +191,52 @@ func TestTransactionBatchWithIntermediateWrongState(t *testing.T) {
 }
 
 func TestTransactionBatchWithConflictingReference(t *testing.T) {
-	runOnLedger(func(l *Ledger) {
-		batch := []core.TransactionData{
-			{
+	t.Run("With conflict reference on transaction set", func(t *testing.T) {
+		runOnLedger(func(l *Ledger) {
+			batch := []core.TransactionData{
+				{
+					Postings: []core.Posting{
+						{
+							Source:      "world",
+							Destination: "player",
+							Asset:       "GEM",
+							Amount:      int64(100),
+						},
+					},
+					Reference: "ref1",
+				},
+				{
+					Postings: []core.Posting{
+						{
+							Source:      "player",
+							Destination: "game",
+							Asset:       "GEM",
+							Amount:      int64(100),
+						},
+					},
+					Reference: "ref2",
+				},
+				{
+					Postings: []core.Posting{
+						{
+							Source:      "player",
+							Destination: "player2",
+							Asset:       "GEM",
+							Amount:      int64(1000), // Should trigger an insufficient fund error but the conflict error has precedence over it
+						},
+					},
+					Reference: "ref1",
+				},
+			}
+
+			_, err := l.Commit(context.Background(), batch)
+			assert.Error(t, err)
+			assert.IsType(t, new(ConflictError), err)
+		})
+	})
+	t.Run("with conflict reference on database", func(t *testing.T) {
+		runOnLedger(func(l *Ledger) {
+			txData := core.TransactionData{
 				Postings: []core.Posting{
 					{
 						Source:      "world",
@@ -203,34 +246,14 @@ func TestTransactionBatchWithConflictingReference(t *testing.T) {
 					},
 				},
 				Reference: "ref1",
-			},
-			{
-				Postings: []core.Posting{
-					{
-						Source:      "player",
-						Destination: "game",
-						Asset:       "GEM",
-						Amount:      int64(100),
-					},
-				},
-				Reference: "ref2",
-			},
-			{
-				Postings: []core.Posting{
-					{
-						Source:      "player",
-						Destination: "player2",
-						Asset:       "GEM",
-						Amount:      int64(1000), // Should trigger an insufficient fund error but the conflict error has precedence over it
-					},
-				},
-				Reference: "ref1",
-			},
-		}
+			}
+			_, err := l.Commit(context.Background(), []core.TransactionData{txData})
+			require.NoError(t, err)
 
-		_, err := l.Commit(context.Background(), batch)
-		assert.Error(t, err)
-		assert.IsType(t, new(ConflictError), err)
+			_, err = l.Commit(context.Background(), []core.TransactionData{txData})
+			assert.Error(t, err)
+			assert.IsType(t, new(ConflictError), err)
+		})
 	})
 }
 


### PR DESCRIPTION
# Change the order of UNSUFFICIENT_FUNDS and CONFLICT errors

Instead of handling conflict errors at store level (by interpreting error codes from the database server), we check potential reference conflict at core level.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt