### PR TITLE
feat: Introduce system store

### DIFF
--- a/cmd/container_test.go
+++ b/cmd/container_test.go
@@ -166,7 +166,7 @@ func TestContainers(t *testing.T) {
 				fx.Invoke(func(lc fx.Lifecycle, t *testing.T, driver storage.Driver, storageFactory storage.Driver) {
 					lc.Append(fx.Hook{
 						OnStart: func(ctx context.Context) error {
-							store, _, err := storageFactory.GetStore(ctx, "testing", true)
+							store, _, err := storageFactory.GetLedgerStore(ctx, "testing", true)
 							if err != nil {
 								return err
 							}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -35,7 +35,7 @@ func NewStorageInit() *cobra.Command {
 								return errors.New("name is empty")
 							}
 							fmt.Printf("Creating ledger '%s'...", name)
-							s, created, err := storageDriver.GetStore(ctx, name, true)
+							s, created, err := storageDriver.GetLedgerStore(ctx, name, true)
 							if err != nil {
 								return err
 							}
@@ -45,7 +45,7 @@ func NewStorageInit() *cobra.Command {
 								return nil
 							}
 
-							_, err = s.Initialize(ctx)
+							_, err = s.Migrate(ctx)
 							if err != nil {
 								return err
 							}
@@ -74,7 +74,11 @@ func NewStorageList() *cobra.Command {
 				fx.Invoke(func(storageDriver storage.Driver, lc fx.Lifecycle) {
 					lc.Append(fx.Hook{
 						OnStart: func(ctx context.Context) error {
-							ledgers, err := storageDriver.List(ctx)
+							systemStore, err := storageDriver.GetSystemStore(ctx)
+							if err != nil {
+								return err
+							}
+							ledgers, err := systemStore.List(ctx)
 							if err != nil {
 								return err
 							}
@@ -108,11 +112,11 @@ func NewStorageUpgrade() *cobra.Command {
 					lc.Append(fx.Hook{
 						OnStart: func(ctx context.Context) error {
 							name := args[0]
-							store, _, err := storageDriver.GetStore(ctx, name, false)
+							store, _, err := storageDriver.GetLedgerStore(ctx, name, false)
 							if err != nil {
 								return err
 							}
-							modified, err := store.Initialize(ctx)
+							modified, err := store.Migrate(ctx)
 							if err != nil {
 								return err
 							}
@@ -170,7 +174,11 @@ func NewStorageScan() *cobra.Command {
 									continue
 								}
 								fmt.Printf("Registering ledger '%s'\r\n", ledgerName)
-								created, err := driver.Register(cmd.Context(), ledgerName)
+								systemStore, err := driver.GetSystemStore(ctx)
+								if err != nil {
+									return err
+								}
+								created, err := systemStore.Register(cmd.Context(), ledgerName)
 								if err != nil {
 									fmt.Printf("Error registering ledger '%s': %s\r\n", ledgerName, err)
 									continue
@@ -214,7 +222,11 @@ func NewStorageScan() *cobra.Command {
 									continue
 								}
 								fmt.Printf("Registering ledger '%s'\r\n", ledgerName)
-								created, err := driver.Register(cmd.Context(), ledgerName)
+								systemStore, err := driver.GetSystemStore(ctx)
+								if err != nil {
+									return err
+								}
+								created, err := systemStore.Register(cmd.Context(), ledgerName)
 								if err != nil {
 									fmt.Printf("Error registering ledger '%s': %s\r\n", ledgerName, err)
 									continue
@@ -249,7 +261,7 @@ func NewStorageDelete() *cobra.Command {
 					lc.Append(fx.Hook{
 						OnStart: func(ctx context.Context) error {
 							name := args[0]
-							err := storageDriver.DeleteStore(ctx, name)
+							err := storageDriver.DeleteLedgerStore(ctx, name)
 							if err != nil {
 								return err
 							}

--- a/pkg/api/controllers/config_controller.go
+++ b/pkg/api/controllers/config_controller.go
@@ -39,7 +39,11 @@ func NewConfigController(version string, storageDriver storage.Driver) ConfigCon
 }
 
 func (ctl *ConfigController) GetInfo(c *gin.Context) {
-	ledgers, err := ctl.StorageDriver.List(c.Request.Context())
+	systemStore, err := ctl.StorageDriver.GetSystemStore(c.Request.Context())
+	if err != nil {
+		panic(err)
+	}
+	ledgers, err := systemStore.List(c.Request.Context())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/api/controllers/transaction_controller_test.go
+++ b/pkg/api/controllers/transaction_controller_test.go
@@ -1135,12 +1135,12 @@ func TestTooManyClient(t *testing.T) {
 					return nil
 				}
 
-				store, _, err := driver.GetStore(context.Background(), "quickstart", true)
+				store, _, err := driver.GetLedgerStore(context.Background(), "quickstart", true)
 				assert.NoError(t, err)
 
 				// Grab all potential connections
 				for i := 0; i < pgtesting.MaxConnections; i++ {
-					tx, err := store.(*sqlstorage.Store).Schema().BeginTx(context.Background(), &sql.TxOptions{})
+					tx, err := store.(*sqlstorage.LedgerStore).Schema().BeginTx(context.Background(), &sql.TxOptions{})
 					assert.NoError(t, err)
 					defer func(tx *sql.Tx) {
 						if err := tx.Rollback(); err != nil {

--- a/pkg/api/internal/testing.go
+++ b/pkg/api/internal/testing.go
@@ -218,8 +218,8 @@ func PostScript(t *testing.T, handler http.Handler, s core.Script, query url.Val
 	return rec
 }
 
-func GetStore(t *testing.T, driver storage.Driver, ctx context.Context) storage.Store {
-	store, _, err := driver.GetStore(ctx, testingLedger, true)
+func GetStore(t *testing.T, driver storage.Driver, ctx context.Context) storage.LedgerStore {
+	store, _, err := driver.GetLedgerStore(ctx, testingLedger, true)
 	require.NoError(t, err)
 	return store
 }
@@ -241,15 +241,15 @@ func RunTest(t *testing.T, options ...fx.Option) {
 		fx.Invoke(func(driver storage.Driver, lc fx.Lifecycle) {
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
-					store, _, err := driver.GetStore(ctx, testingLedger, true)
+					store, _, err := driver.GetLedgerStore(ctx, testingLedger, true)
 					if err != nil {
 						return err
 					}
-					defer func(store storage.Store, ctx context.Context) {
+					defer func(store storage.LedgerStore, ctx context.Context) {
 						require.NoError(t, store.Close(ctx))
 					}(store, ctx)
 
-					_, err = store.Initialize(ctx)
+					_, err = store.Migrate(ctx)
 					return err
 				},
 			})

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -27,11 +27,11 @@ var DefaultContracts = []core.Contract{
 
 type Ledger struct {
 	locker  Locker
-	store   storage.Store
+	store   storage.LedgerStore
 	monitor Monitor
 }
 
-func NewLedger(store storage.Store, locker Locker, monitor Monitor) (*Ledger, error) {
+func NewLedger(store storage.LedgerStore, locker Locker, monitor Monitor) (*Ledger, error) {
 	return &Ledger{
 		store:   store,
 		locker:  locker,

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -61,11 +61,11 @@ func runOnLedger(f func(l *Ledger)) {
 		lc.Append(fx.Hook{
 			OnStart: func(ctx context.Context) error {
 				name := uuid.New()
-				store, _, err := storageDriver.GetStore(context.Background(), name, true)
+				store, _, err := storageDriver.GetLedgerStore(context.Background(), name, true)
 				if err != nil {
 					return err
 				}
-				_, err = store.Initialize(context.Background())
+				_, err = store.Migrate(context.Background())
 				if err != nil {
 					return err
 				}

--- a/pkg/ledger/resolver.go
+++ b/pkg/ledger/resolver.go
@@ -62,7 +62,7 @@ func NewResolver(storageFactory storage.Driver, options ...ResolverOption) *Reso
 }
 
 func (r *Resolver) GetLedger(ctx context.Context, name string) (*Ledger, error) {
-	store, _, err := r.storageDriver.GetStore(ctx, name, true)
+	store, _, err := r.storageDriver.GetLedgerStore(ctx, name, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving ledger store")
 	}
@@ -78,7 +78,7 @@ func (r *Resolver) GetLedger(ctx context.Context, name string) (*Ledger, error) 
 	defer r.lock.Unlock()
 
 	if _, ok = r.initializedStores[name]; !ok {
-		_, err = store.Initialize(ctx)
+		_, err = store.Migrate(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing ledger store")
 		}

--- a/pkg/ledger/volume_agg.go
+++ b/pkg/ledger/volume_agg.go
@@ -71,7 +71,7 @@ func (tva *transactionVolumeAggregator) transfer(ctx context.Context, from, to, 
 }
 
 type volumeAggregator struct {
-	store storage.Store
+	store storage.LedgerStore
 	txs   []*transactionVolumeAggregator
 }
 
@@ -126,7 +126,7 @@ func (agg *volumeAggregator) aggregatedPreCommitVolumes() core.AccountsAssetsVol
 	return ret
 }
 
-func newVolumeAggregator(store storage.Store) *volumeAggregator {
+func newVolumeAggregator(store storage.LedgerStore) *volumeAggregator {
 	return &volumeAggregator{
 		store: store,
 	}

--- a/pkg/ledger/volume_agg_test.go
+++ b/pkg/ledger/volume_agg_test.go
@@ -17,12 +17,12 @@ func TestVolumeAggregator(t *testing.T) {
 			OnStart: func(ctx context.Context) error {
 				name := uuid.New()
 
-				store, _, err := storageDriver.GetStore(context.Background(), name, true)
+				store, _, err := storageDriver.GetLedgerStore(context.Background(), name, true)
 				if err != nil {
 					return err
 				}
 
-				_, err = store.Initialize(context.Background())
+				_, err = store.Migrate(context.Background())
 				if err != nil {
 					return err
 				}

--- a/pkg/opentelemetry/opentelemetrymetrics/storage_test.go
+++ b/pkg/opentelemetry/opentelemetrymetrics/storage_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestWrapStorageFactory(t *testing.T) {
 	f := WrapStorageDriver(storage.NoOpDriver(), global.GetMeterProvider())
-	store, _, err := f.GetStore(context.Background(), "bar", true)
+	store, _, err := f.GetLedgerStore(context.Background(), "bar", true)
 	assert.NoError(t, err)
 	assert.NotNil(t, store)
 	assert.IsType(t, new(storageDecorator), store)

--- a/pkg/opentelemetry/opentelemetrytraces/storage.go
+++ b/pkg/opentelemetry/opentelemetrytraces/storage.go
@@ -16,7 +16,7 @@ import (
 )
 
 type openTelemetryStorage struct {
-	underlying storage.Store
+	underlying storage.LedgerStore
 }
 
 func (o *openTelemetryStorage) handle(ctx context.Context, name string, fn func(ctx context.Context) error) error {
@@ -211,9 +211,9 @@ func (o *openTelemetryStorage) SaveMapping(ctx context.Context, mapping core.Map
 	})
 }
 
-func (o *openTelemetryStorage) Initialize(ctx context.Context) (ret bool, err error) {
+func (o *openTelemetryStorage) Migrate(ctx context.Context) (ret bool, err error) {
 	handlingErr := o.handle(ctx, "Initialize", func(ctx context.Context) error {
-		ret, err = o.underlying.Initialize(ctx)
+		ret, err = o.underlying.Migrate(ctx)
 		return nil
 	})
 	if handlingErr != nil {
@@ -232,9 +232,9 @@ func (o *openTelemetryStorage) Close(ctx context.Context) error {
 	})
 }
 
-var _ storage.Store = &openTelemetryStorage{}
+var _ storage.LedgerStore = &openTelemetryStorage{}
 
-func NewStorageDecorator(underlying storage.Store) *openTelemetryStorage {
+func NewStorageDecorator(underlying storage.LedgerStore) *openTelemetryStorage {
 	return &openTelemetryStorage{
 		underlying: underlying,
 	}
@@ -244,8 +244,8 @@ type openTelemetryStorageDriver struct {
 	storage.Driver
 }
 
-func (o openTelemetryStorageDriver) GetStore(ctx context.Context, name string, create bool) (storage.Store, bool, error) {
-	store, created, err := o.Driver.GetStore(ctx, name, create)
+func (o openTelemetryStorageDriver) GetLedgerStore(ctx context.Context, name string, create bool) (storage.LedgerStore, bool, error) {
+	store, created, err := o.Driver.GetLedgerStore(ctx, name, create)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/opentelemetry/opentelemetrytraces/storage_test.go
+++ b/pkg/opentelemetry/opentelemetrytraces/storage_test.go
@@ -18,7 +18,7 @@ func TestStore(t *testing.T) {
 
 	type testingFunction struct {
 		name string
-		fn   func(t *testing.T, store storage.Store)
+		fn   func(t *testing.T, store storage.LedgerStore)
 	}
 
 	for _, tf := range []testingFunction{
@@ -63,7 +63,7 @@ func TestStore(t *testing.T) {
 				}
 			}(store, context.Background())
 
-			_, err := store.Initialize(context.Background())
+			_, err := store.Migrate(context.Background())
 			assert.NoError(t, err)
 
 			tf.fn(t, store)
@@ -71,47 +71,47 @@ func TestStore(t *testing.T) {
 	}
 }
 
-func testAppendLog(t *testing.T, store storage.Store) {
+func testAppendLog(t *testing.T, store storage.LedgerStore) {
 	err := store.AppendLog(context.Background(), core.NewTransactionLog(nil, core.Transaction{}))
 	assert.NoError(t, err)
 }
 
-func testLastLog(t *testing.T, store storage.Store) {
+func testLastLog(t *testing.T, store storage.LedgerStore) {
 	_, err := store.LastLog(context.Background())
 	assert.NoError(t, err)
 }
 
-func testCountAccounts(t *testing.T, store storage.Store) {
+func testCountAccounts(t *testing.T, store storage.LedgerStore) {
 	_, err := store.CountAccounts(context.Background(), storage.AccountsQuery{})
 	assert.NoError(t, err)
 
 }
 
-func testAggregateVolumes(t *testing.T, store storage.Store) {
+func testAggregateVolumes(t *testing.T, store storage.LedgerStore) {
 	_, err := store.GetAssetsVolumes(context.Background(), "central_bank")
 	assert.NoError(t, err)
 }
 
-func testGetAccounts(t *testing.T, store storage.Store) {
+func testGetAccounts(t *testing.T, store storage.LedgerStore) {
 	_, err := store.GetAccounts(context.Background(), storage.AccountsQuery{
 		PageSize: 1,
 	})
 	assert.NoError(t, err)
 }
 
-func testCountTransactions(t *testing.T, store storage.Store) {
+func testCountTransactions(t *testing.T, store storage.LedgerStore) {
 	_, err := store.CountTransactions(context.Background(), storage.TransactionsQuery{})
 	assert.NoError(t, err)
 }
 
-func testGetTransactions(t *testing.T, store storage.Store) {
+func testGetTransactions(t *testing.T, store storage.LedgerStore) {
 	_, err := store.GetTransactions(context.Background(), storage.TransactionsQuery{
 		PageSize: 1,
 	})
 	assert.NoError(t, err)
 }
 
-func testGetTransaction(t *testing.T, store storage.Store) {
+func testGetTransaction(t *testing.T, store storage.LedgerStore) {
 	_, err := store.GetTransaction(context.Background(), 1)
 	assert.NoError(t, err)
 }

--- a/pkg/storage/driver.go
+++ b/pkg/storage/driver.go
@@ -6,16 +6,32 @@ import (
 
 type Driver interface {
 	Initialize(ctx context.Context) error
-	GetStore(ctx context.Context, name string, create bool) (Store, bool, error)
+	GetLedgerStore(ctx context.Context, name string, create bool) (LedgerStore, bool, error)
+	DeleteLedgerStore(ctx context.Context, name string) error
+	GetSystemStore(ctx context.Context) (SystemStore, error)
 	Close(ctx context.Context) error
-	List(ctx context.Context) ([]string, error)
-	DeleteStore(ctx context.Context, name string) error
 	Name() string
 }
 
 type noOpDriver struct{}
 
-func (n noOpDriver) DeleteStore(ctx context.Context, name string) error {
+func (n noOpDriver) Register(ctx context.Context, ledger string) (bool, error) {
+	return false, nil
+}
+
+func (n noOpDriver) Exists(ctx context.Context, ledger string) (bool, error) {
+	return false, nil
+}
+
+func (n noOpDriver) Delete(ctx context.Context, ledger string) error {
+	return nil
+}
+
+func (n noOpDriver) GetSystemStore(ctx context.Context) (SystemStore, error) {
+	return n, nil
+}
+
+func (n noOpDriver) DeleteLedgerStore(ctx context.Context, name string) error {
 	return nil
 }
 
@@ -23,7 +39,7 @@ func (n noOpDriver) Initialize(ctx context.Context) error {
 	return nil
 }
 
-func (n noOpDriver) GetStore(ctx context.Context, name string, create bool) (Store, bool, error) {
+func (n noOpDriver) GetLedgerStore(ctx context.Context, name string, create bool) (LedgerStore, bool, error) {
 	return nil, false, nil
 }
 

--- a/pkg/storage/sqlstorage/accounts.go
+++ b/pkg/storage/sqlstorage/accounts.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *Store) buildAccountsQuery(p storage.AccountsQuery) (*sqlbuilder.SelectBuilder, AccPaginationToken) {
+func (s *LedgerStore) buildAccountsQuery(p storage.AccountsQuery) (*sqlbuilder.SelectBuilder, AccPaginationToken) {
 	sb := sqlbuilder.NewSelectBuilder()
 	t := AccPaginationToken{}
 	sb.From(s.schema.Table("accounts"))
@@ -86,7 +86,7 @@ func (s *Store) buildAccountsQuery(p storage.AccountsQuery) (*sqlbuilder.SelectB
 	return sb, t
 }
 
-func (s *Store) getAccounts(ctx context.Context, exec executor, q storage.AccountsQuery) (sharedapi.Cursor[core.Account], error) {
+func (s *LedgerStore) getAccounts(ctx context.Context, exec executor, q storage.AccountsQuery) (sharedapi.Cursor[core.Account], error) {
 	accounts := make([]core.Account, 0)
 
 	if q.PageSize == 0 {
@@ -166,11 +166,11 @@ func (s *Store) getAccounts(ctx context.Context, exec executor, q storage.Accoun
 	}, nil
 }
 
-func (s *Store) GetAccounts(ctx context.Context, q storage.AccountsQuery) (sharedapi.Cursor[core.Account], error) {
+func (s *LedgerStore) GetAccounts(ctx context.Context, q storage.AccountsQuery) (sharedapi.Cursor[core.Account], error) {
 	return s.getAccounts(ctx, s.schema, q)
 }
 
-func (s *Store) getAccount(ctx context.Context, exec executor, addr string) (*core.Account, error) {
+func (s *LedgerStore) getAccount(ctx context.Context, exec executor, addr string) (*core.Account, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("address", "metadata").
 		From(s.schema.Table("accounts")).
@@ -197,6 +197,6 @@ func (s *Store) getAccount(ctx context.Context, exec executor, addr string) (*co
 	return &account, nil
 }
 
-func (s *Store) GetAccount(ctx context.Context, addr string) (*core.Account, error) {
+func (s *LedgerStore) GetAccount(ctx context.Context, addr string) (*core.Account, error) {
 	return s.getAccount(ctx, s.schema, addr)
 }

--- a/pkg/storage/sqlstorage/accounts_test.go
+++ b/pkg/storage/sqlstorage/accounts_test.go
@@ -22,10 +22,10 @@ func TestAccounts(t *testing.T) {
 		assert.NoError(t, d.Close(ctx))
 	}(d, context.Background())
 
-	store, _, err := d.GetStore(context.Background(), "foo", true)
+	store, _, err := d.GetLedgerStore(context.Background(), "foo", true)
 	assert.NoError(t, err)
 
-	_, err = store.Initialize(context.Background())
+	_, err = store.Migrate(context.Background())
 	assert.NoError(t, err)
 
 	t.Run("success balance", func(t *testing.T) {

--- a/pkg/storage/sqlstorage/aggregations.go
+++ b/pkg/storage/sqlstorage/aggregations.go
@@ -10,7 +10,7 @@ import (
 	"github.com/numary/ledger/pkg/storage"
 )
 
-func (s *Store) countTransactions(ctx context.Context, exec executor, tq storage.TransactionsQuery) (uint64, error) {
+func (s *LedgerStore) countTransactions(ctx context.Context, exec executor, tq storage.TransactionsQuery) (uint64, error) {
 	var count uint64
 
 	sb, _ := s.buildTransactionsQuery(tq)
@@ -21,11 +21,11 @@ func (s *Store) countTransactions(ctx context.Context, exec executor, tq storage
 	return count, s.error(err)
 }
 
-func (s *Store) CountTransactions(ctx context.Context, q storage.TransactionsQuery) (uint64, error) {
+func (s *LedgerStore) CountTransactions(ctx context.Context, q storage.TransactionsQuery) (uint64, error) {
 	return s.countTransactions(ctx, s.schema, q)
 }
 
-func (s *Store) countAccounts(ctx context.Context, exec executor, q storage.AccountsQuery) (uint64, error) {
+func (s *LedgerStore) countAccounts(ctx context.Context, exec executor, q storage.AccountsQuery) (uint64, error) {
 	var count uint64
 
 	sb, _ := s.buildAccountsQuery(q)
@@ -35,11 +35,11 @@ func (s *Store) countAccounts(ctx context.Context, exec executor, q storage.Acco
 	return count, s.error(err)
 }
 
-func (s *Store) CountAccounts(ctx context.Context, q storage.AccountsQuery) (uint64, error) {
+func (s *LedgerStore) CountAccounts(ctx context.Context, q storage.AccountsQuery) (uint64, error) {
 	return s.countAccounts(ctx, s.schema, q)
 }
 
-func (s *Store) getAssetsVolumes(ctx context.Context, exec executor, accountAddress string) (core.AssetsVolumes, error) {
+func (s *LedgerStore) getAssetsVolumes(ctx context.Context, exec executor, accountAddress string) (core.AssetsVolumes, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("asset", "input", "output")
 	sb.From(s.schema.Table("volumes"))
@@ -80,11 +80,11 @@ func (s *Store) getAssetsVolumes(ctx context.Context, exec executor, accountAddr
 	return volumes, nil
 }
 
-func (s *Store) GetAssetsVolumes(ctx context.Context, accountAddress string) (core.AssetsVolumes, error) {
+func (s *LedgerStore) GetAssetsVolumes(ctx context.Context, accountAddress string) (core.AssetsVolumes, error) {
 	return s.getAssetsVolumes(ctx, s.schema, accountAddress)
 }
 
-func (s *Store) getVolumes(ctx context.Context, exec executor, accountAddress, asset string) (core.Volumes, error) {
+func (s *LedgerStore) getVolumes(ctx context.Context, exec executor, accountAddress, asset string) (core.Volumes, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("input", "output")
 	sb.From(s.schema.Table("volumes"))
@@ -110,6 +110,6 @@ func (s *Store) getVolumes(ctx context.Context, exec executor, accountAddress, a
 	}, nil
 }
 
-func (s *Store) GetVolumes(ctx context.Context, accountAddress, asset string) (core.Volumes, error) {
+func (s *LedgerStore) GetVolumes(ctx context.Context, accountAddress, asset string) (core.Volumes, error) {
 	return s.getVolumes(ctx, s.schema, accountAddress, asset)
 }

--- a/pkg/storage/sqlstorage/balances.go
+++ b/pkg/storage/sqlstorage/balances.go
@@ -15,7 +15,7 @@ import (
 	"github.com/numary/ledger/pkg/storage"
 )
 
-func (s *Store) getBalancesAggregated(ctx context.Context, exec executor, q storage.BalancesQuery) (core.AssetsBalances, error) {
+func (s *LedgerStore) getBalancesAggregated(ctx context.Context, exec executor, q storage.BalancesQuery) (core.AssetsBalances, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("asset", "sum(input - output)")
 	sb.From(s.schema.Table("volumes"))
@@ -63,11 +63,11 @@ func (s *Store) getBalancesAggregated(ctx context.Context, exec executor, q stor
 	return aggregatedBalances, nil
 }
 
-func (s *Store) GetBalancesAggregated(ctx context.Context, q storage.BalancesQuery) (core.AssetsBalances, error) {
+func (s *LedgerStore) GetBalancesAggregated(ctx context.Context, q storage.BalancesQuery) (core.AssetsBalances, error) {
 	return s.getBalancesAggregated(ctx, s.schema, q)
 }
 
-func (s *Store) getBalances(ctx context.Context, exec executor, q storage.BalancesQuery) (sharedapi.Cursor[core.AccountsBalances], error) {
+func (s *LedgerStore) getBalances(ctx context.Context, exec executor, q storage.BalancesQuery) (sharedapi.Cursor[core.AccountsBalances], error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	switch s.Schema().Flavor() {
 	case sqlbuilder.PostgreSQL:
@@ -184,6 +184,6 @@ func (s *Store) getBalances(ctx context.Context, exec executor, q storage.Balanc
 	}, nil
 }
 
-func (s *Store) GetBalances(ctx context.Context, q storage.BalancesQuery) (sharedapi.Cursor[core.AccountsBalances], error) {
+func (s *LedgerStore) GetBalances(ctx context.Context, q storage.BalancesQuery) (sharedapi.Cursor[core.AccountsBalances], error) {
 	return s.getBalances(ctx, s.schema, q)
 }

--- a/pkg/storage/sqlstorage/balances_test.go
+++ b/pkg/storage/sqlstorage/balances_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testGetBalances(t *testing.T, store *sqlstorage.Store) {
+func testGetBalances(t *testing.T, store *sqlstorage.LedgerStore) {
 	log1 := core.NewTransactionLog(nil, tx1)
 	log2 := core.NewTransactionLog(&log1, tx2)
 	log3 := core.NewTransactionLog(&log2, tx3)
@@ -133,7 +133,7 @@ func testGetBalances(t *testing.T, store *sqlstorage.Store) {
 	})
 }
 
-func testGetBalancesAggregated(t *testing.T, store *sqlstorage.Store) {
+func testGetBalancesAggregated(t *testing.T, store *sqlstorage.LedgerStore) {
 	log1 := core.NewTransactionLog(nil, tx1)
 	log2 := core.NewTransactionLog(&log1, tx2)
 	log3 := core.NewTransactionLog(&log2, tx3)

--- a/pkg/storage/sqlstorage/driver_test.go
+++ b/pkg/storage/sqlstorage/driver_test.go
@@ -21,15 +21,15 @@ func TestNewDriver(t *testing.T) {
 		assert.NoError(t, d.Close(ctx))
 	}(d, context.Background())
 
-	store, _, err := d.GetStore(context.Background(), "foo", true)
+	store, _, err := d.GetLedgerStore(context.Background(), "foo", true)
 	assert.NoError(t, err)
 
-	_, err = store.Initialize(context.Background())
+	_, err = store.Migrate(context.Background())
 	assert.NoError(t, err)
 
 	assert.NoError(t, store.Close(context.Background()))
 
-	_, err = store.(*Store).schema.QueryContext(context.Background(), "select * from transactions")
+	_, err = store.(*LedgerStore).schema.QueryContext(context.Background(), "select * from transactions")
 	assert.Error(t, err)
 	assert.Equal(t, "sql: database is closed [UNKNOWN]", err.Error())
 }

--- a/pkg/storage/sqlstorage/ledger_store.go
+++ b/pkg/storage/sqlstorage/ledger_store.go
@@ -12,34 +12,34 @@ const (
 	SQLCustomFuncMetaCompare = "meta_compare"
 )
 
-type Store struct {
+type LedgerStore struct {
 	schema  Schema
 	onClose func(ctx context.Context) error
 }
 
-func (s *Store) Schema() Schema {
+func (s *LedgerStore) Schema() Schema {
 	return s.schema
 }
 
-func (s *Store) error(err error) error {
+func (s *LedgerStore) error(err error) error {
 	if err == nil {
 		return nil
 	}
 	return errorFromFlavor(Flavor(s.schema.Flavor()), err)
 }
 
-func NewStore(schema Schema, onClose func(ctx context.Context) error) (*Store, error) {
-	return &Store{
+func NewStore(schema Schema, onClose func(ctx context.Context) error) (*LedgerStore, error) {
+	return &LedgerStore{
 		schema:  schema,
 		onClose: onClose,
 	}, nil
 }
 
-func (s *Store) Name() string {
+func (s *LedgerStore) Name() string {
 	return s.schema.Name()
 }
 
-func (s *Store) Initialize(ctx context.Context) (bool, error) {
+func (s *LedgerStore) Migrate(ctx context.Context) (bool, error) {
 	sharedlogging.GetLogger(ctx).Debug("Initialize store")
 
 	migrations, err := CollectMigrationFiles(MigrationsFS)
@@ -50,8 +50,8 @@ func (s *Store) Initialize(ctx context.Context) (bool, error) {
 	return Migrate(ctx, s.schema, migrations...)
 }
 
-func (s *Store) Close(ctx context.Context) error {
+func (s *LedgerStore) Close(ctx context.Context) error {
 	return s.onClose(ctx)
 }
 
-var _ storage.Store = &Store{}
+var _ storage.LedgerStore = &LedgerStore{}

--- a/pkg/storage/sqlstorage/log.go
+++ b/pkg/storage/sqlstorage/log.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *Store) appendLog(ctx context.Context, exec executor, log ...core.Log) error {
+func (s *LedgerStore) appendLog(ctx context.Context, exec executor, log ...core.Log) error {
 	var (
 		query string
 		args  []interface{}
@@ -68,7 +68,7 @@ func (s *Store) appendLog(ctx context.Context, exec executor, log ...core.Log) e
 	return nil
 }
 
-func (s *Store) AppendLog(ctx context.Context, logs ...core.Log) error {
+func (s *LedgerStore) AppendLog(ctx context.Context, logs ...core.Log) error {
 	tx, err := s.schema.BeginTx(ctx, nil)
 	if err != nil {
 		return s.error(err)
@@ -88,7 +88,7 @@ func (s *Store) AppendLog(ctx context.Context, logs ...core.Log) error {
 	return nil
 }
 
-func (s *Store) lastLog(ctx context.Context, exec executor) (*core.Log, error) {
+func (s *LedgerStore) lastLog(ctx context.Context, exec executor) (*core.Log, error) {
 	var (
 		l    core.Log
 		data sql.NullString
@@ -119,11 +119,11 @@ func (s *Store) lastLog(ctx context.Context, exec executor) (*core.Log, error) {
 	return &l, nil
 }
 
-func (s *Store) LastLog(ctx context.Context) (*core.Log, error) {
+func (s *LedgerStore) LastLog(ctx context.Context) (*core.Log, error) {
 	return s.lastLog(ctx, s.schema)
 }
 
-func (s *Store) logs(ctx context.Context, exec executor) ([]core.Log, error) {
+func (s *LedgerStore) logs(ctx context.Context, exec executor) ([]core.Log, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.From(s.schema.Table("log"))
 	sb.Select("id", "type", "hash", "date", "data")
@@ -169,6 +169,6 @@ func (s *Store) logs(ctx context.Context, exec executor) ([]core.Log, error) {
 	return ret, nil
 }
 
-func (s *Store) Logs(ctx context.Context) ([]core.Log, error) {
+func (s *LedgerStore) Logs(ctx context.Context) ([]core.Log, error) {
 	return s.logs(ctx, s.schema)
 }

--- a/pkg/storage/sqlstorage/mapping.go
+++ b/pkg/storage/sqlstorage/mapping.go
@@ -12,7 +12,7 @@ import (
 // We have only one mapping for a ledger, so hardcode the id
 const mappingId = "0000"
 
-func (s *Store) loadMapping(ctx context.Context, exec executor) (*core.Mapping, error) {
+func (s *LedgerStore) loadMapping(ctx context.Context, exec executor) (*core.Mapping, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("mapping").From(s.schema.Table("mapping"))
 
@@ -35,11 +35,11 @@ func (s *Store) loadMapping(ctx context.Context, exec executor) (*core.Mapping, 
 	return &m, nil
 }
 
-func (s *Store) LoadMapping(ctx context.Context) (*core.Mapping, error) {
+func (s *LedgerStore) LoadMapping(ctx context.Context) (*core.Mapping, error) {
 	return s.loadMapping(ctx, s.schema)
 }
 
-func (s *Store) saveMapping(ctx context.Context, exec executor, mapping core.Mapping) error {
+func (s *LedgerStore) saveMapping(ctx context.Context, exec executor, mapping core.Mapping) error {
 	data, err := json.Marshal(mapping)
 	if err != nil {
 		return err
@@ -67,6 +67,6 @@ func (s *Store) saveMapping(ctx context.Context, exec executor, mapping core.Map
 	return s.error(err)
 }
 
-func (s *Store) SaveMapping(ctx context.Context, mapping core.Mapping) error {
+func (s *LedgerStore) SaveMapping(ctx context.Context, mapping core.Mapping) error {
 	return s.saveMapping(ctx, s.schema, mapping)
 }

--- a/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any_test.go
+++ b/pkg/storage/sqlstorage/migrates/9-add-pre-post-volumes/any_test.go
@@ -195,10 +195,10 @@ func TestMigrate9(t *testing.T) {
 	defer closeFunc()
 
 	require.NoError(t, driver.Initialize(context.Background()))
-	store, _, err := driver.GetStore(context.Background(), uuid.New(), true)
+	store, _, err := driver.GetLedgerStore(context.Background(), uuid.New(), true)
 	require.NoError(t, err)
 
-	schema := store.(*sqlstorage.Store).Schema()
+	schema := store.(*sqlstorage.LedgerStore).Schema()
 
 	migrations, err := sqlstorage.CollectMigrationFiles(sqlstorage.MigrationsFS)
 	require.NoError(t, err)

--- a/pkg/storage/sqlstorage/schema.go
+++ b/pkg/storage/sqlstorage/schema.go
@@ -15,7 +15,7 @@ type Schema interface {
 	executor
 	Initialize(ctx context.Context) error
 	Table(name string) string
-	Close(ctx context.Context) error
+	close(ctx context.Context) error
 	BeginTx(ctx context.Context, s *sql.TxOptions) (*sql.Tx, error)
 	Flavor() sqlbuilder.Flavor
 	Name() string
@@ -44,7 +44,7 @@ func (s *baseSchema) ExecContext(ctx context.Context, query string, args ...inte
 	sharedlogging.GetLogger(ctx).Debugf("ExecContext: %s %s", query, args)
 	return s.DB.ExecContext(ctx, query, args...)
 }
-func (s *baseSchema) Close(ctx context.Context) error {
+func (s *baseSchema) close(ctx context.Context) error {
 	if s.closeDb {
 		return s.DB.Close()
 	}
@@ -132,7 +132,7 @@ func (s *SQLiteSchema) ExecContext(ctx context.Context, query string, args ...in
 }
 
 type DB interface {
-	Initialize(ctx context.Context) error
+	initialize(ctx context.Context) error
 	Schema(ctx context.Context, name string) (Schema, error)
 	Close(ctx context.Context) error
 }
@@ -141,7 +141,7 @@ type postgresDB struct {
 	db *sql.DB
 }
 
-func (p *postgresDB) Initialize(ctx context.Context) error {
+func (p *postgresDB) initialize(ctx context.Context) error {
 	_, err := p.db.ExecContext(ctx, "CREATE EXTENSION IF NOT EXISTS pgcrypto")
 	if err != nil {
 		return err
@@ -174,7 +174,7 @@ type sqliteDB struct {
 	dbName    string
 }
 
-func (p *sqliteDB) Initialize(ctx context.Context) error {
+func (p *sqliteDB) initialize(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/storage/sqlstorage/store_bench_test.go
+++ b/pkg/storage/sqlstorage/store_bench_test.go
@@ -57,7 +57,7 @@ func BenchmarkStore(b *testing.B) {
 
 	type testingFunction struct {
 		name string
-		fn   func(b *testing.B, store *sqlstorage.Store)
+		fn   func(b *testing.B, store *sqlstorage.LedgerStore)
 	}
 
 	for _, driver := range drivers {
@@ -94,11 +94,11 @@ func BenchmarkStore(b *testing.B) {
 					return db.Close(context.Background())
 				})
 				assert.NoError(b, err)
-				defer func(store *sqlstorage.Store, ctx context.Context) {
+				defer func(store *sqlstorage.LedgerStore, ctx context.Context) {
 					require.NoError(b, store.Close(ctx))
 				}(store, context.Background())
 
-				_, err = store.Initialize(context.Background())
+				_, err = store.Migrate(context.Background())
 				assert.NoError(b, err)
 
 				b.ResetTimer()
@@ -109,7 +109,7 @@ func BenchmarkStore(b *testing.B) {
 	}
 }
 
-func testBenchmarkGetTransactions(b *testing.B, store *sqlstorage.Store) {
+func testBenchmarkGetTransactions(b *testing.B, store *sqlstorage.LedgerStore) {
 	var log *core.Log
 	for i := 0; i < 1000; i++ {
 		tx := core.Transaction{
@@ -149,7 +149,7 @@ func testBenchmarkGetTransactions(b *testing.B, store *sqlstorage.Store) {
 
 }
 
-func testBenchmarkLastLog(b *testing.B, store *sqlstorage.Store) {
+func testBenchmarkLastLog(b *testing.B, store *sqlstorage.LedgerStore) {
 	var log *core.Log
 	count := 1000
 	for i := 0; i < count; i++ {
@@ -186,7 +186,7 @@ func testBenchmarkLastLog(b *testing.B, store *sqlstorage.Store) {
 
 }
 
-func testBenchmarkAggregateVolumes(b *testing.B, store *sqlstorage.Store) {
+func testBenchmarkAggregateVolumes(b *testing.B, store *sqlstorage.LedgerStore) {
 	count := 1000
 	var log *core.Log
 	for i := 0; i < count; i++ {
@@ -228,7 +228,7 @@ func testBenchmarkAggregateVolumes(b *testing.B, store *sqlstorage.Store) {
 
 }
 
-func testBenchmarkSaveTransactions(b *testing.B, store *sqlstorage.Store) {
+func testBenchmarkSaveTransactions(b *testing.B, store *sqlstorage.LedgerStore) {
 	var log *core.Log
 	for n := 0; n < b.N; n++ {
 		*log = core.NewTransactionLog(log, core.Transaction{

--- a/pkg/storage/sqlstorage/system_store.go
+++ b/pkg/storage/sqlstorage/system_store.go
@@ -1,0 +1,103 @@
+package sqlstorage
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/huandu/go-sqlbuilder"
+	"github.com/numary/ledger/pkg/storage"
+)
+
+type SystemStore struct {
+	schema Schema
+}
+
+func (s SystemStore) Delete(ctx context.Context, ledger string) error {
+	b := sqlbuilder.DeleteFrom(s.schema.Table("ledgers"))
+	b = b.Where(b.E("ledger", ledger))
+	q, args := b.BuildWithFlavor(s.schema.Flavor())
+	_, err := s.schema.ExecContext(ctx, q, args...)
+	return err
+}
+
+func (s SystemStore) initialize(ctx context.Context) error {
+	if err := s.schema.Initialize(ctx); err != nil {
+		return err
+	}
+	q, args := sqlbuilder.
+		CreateTable(s.schema.Table("ledgers")).
+		Define("ledger varchar(255) primary key, addedAt timestamp").
+		IfNotExists().
+		BuildWithFlavor(s.schema.Flavor())
+
+	_, err := s.schema.ExecContext(ctx, q, args...)
+	return err
+}
+
+func (s SystemStore) List(ctx context.Context) ([]string, error) {
+	q, args := sqlbuilder.
+		Select("ledger").
+		From(s.schema.Table("ledgers")).
+		BuildWithFlavor(s.schema.Flavor())
+	rows, err := s.schema.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func(rows *sql.Rows) {
+		if err := rows.Close(); err != nil {
+			panic(err)
+		}
+	}(rows)
+
+	res := make([]string, 0)
+	for rows.Next() {
+		var ledger string
+		if err := rows.Scan(&ledger); err != nil {
+			return nil, err
+		}
+		res = append(res, ledger)
+	}
+	return res, nil
+}
+
+func (s *SystemStore) Register(ctx context.Context, ledger string) (bool, error) {
+	q, args := sqlbuilder.
+		InsertInto(s.schema.Table("ledgers")).
+		Cols("ledger", "addedAt").
+		Values(ledger, time.Now()).
+		SQL("ON CONFLICT DO NOTHING").
+		BuildWithFlavor(s.schema.Flavor())
+
+	ret, err := s.schema.ExecContext(ctx, q, args...)
+	if err != nil {
+		return false, err
+	}
+	affected, err := ret.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+func (s *SystemStore) Exists(ctx context.Context, ledger string) (bool, error) {
+	b := sqlbuilder.
+		Select("ledger").
+		From(s.schema.Table("ledgers"))
+
+	q, args := b.Where(b.E("ledger", ledger)).BuildWithFlavor(s.schema.Flavor())
+
+	ret := s.schema.QueryRowContext(ctx, q, args...)
+	if ret.Err() != nil {
+		return false, nil
+	}
+	var t string
+	_ = ret.Scan(&t) // Trigger close
+	return true, nil
+}
+
+func (s *SystemStore) close(ctx context.Context) error {
+	return s.schema.close(ctx)
+}
+
+var _ storage.SystemStore = &SystemStore{}

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -15,7 +15,7 @@ import (
 	"github.com/numary/ledger/pkg/storage"
 )
 
-func (s *Store) buildTransactionsQuery(p storage.TransactionsQuery) (*sqlbuilder.SelectBuilder, TxsPaginationToken) {
+func (s *LedgerStore) buildTransactionsQuery(p storage.TransactionsQuery) (*sqlbuilder.SelectBuilder, TxsPaginationToken) {
 	sb := sqlbuilder.NewSelectBuilder()
 	t := TxsPaginationToken{}
 
@@ -71,7 +71,7 @@ func (s *Store) buildTransactionsQuery(p storage.TransactionsQuery) (*sqlbuilder
 	return sb, t
 }
 
-func (s *Store) getTransactions(ctx context.Context, exec executor, q storage.TransactionsQuery) (sharedapi.Cursor[core.Transaction], error) {
+func (s *LedgerStore) getTransactions(ctx context.Context, exec executor, q storage.TransactionsQuery) (sharedapi.Cursor[core.Transaction], error) {
 	txs := make([]core.Transaction, 0)
 
 	if q.PageSize == 0 {
@@ -161,11 +161,11 @@ func (s *Store) getTransactions(ctx context.Context, exec executor, q storage.Tr
 	}, nil
 }
 
-func (s *Store) GetTransactions(ctx context.Context, q storage.TransactionsQuery) (sharedapi.Cursor[core.Transaction], error) {
+func (s *LedgerStore) GetTransactions(ctx context.Context, q storage.TransactionsQuery) (sharedapi.Cursor[core.Transaction], error) {
 	return s.getTransactions(ctx, s.schema, q)
 }
 
-func (s *Store) getTransaction(ctx context.Context, exec executor, txid uint64) (*core.Transaction, error) {
+func (s *LedgerStore) getTransaction(ctx context.Context, exec executor, txid uint64) (*core.Transaction, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("id", "timestamp", "reference", "metadata", "postings", "pre_commit_volumes", "post_commit_volumes")
 	sb.From(s.schema.Table("transactions"))
@@ -213,11 +213,11 @@ func (s *Store) getTransaction(ctx context.Context, exec executor, txid uint64) 
 	return &tx, nil
 }
 
-func (s *Store) GetTransaction(ctx context.Context, txId uint64) (*core.Transaction, error) {
+func (s *LedgerStore) GetTransaction(ctx context.Context, txId uint64) (*core.Transaction, error) {
 	return s.getTransaction(ctx, s.schema, txId)
 }
 
-func (s *Store) getLastTransaction(ctx context.Context, exec executor) (*core.Transaction, error) {
+func (s *LedgerStore) getLastTransaction(ctx context.Context, exec executor) (*core.Transaction, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("id", "timestamp", "reference", "metadata", "postings", "pre_commit_volumes", "post_commit_volumes")
 	sb.From(s.schema.Table("transactions"))
@@ -265,6 +265,6 @@ func (s *Store) getLastTransaction(ctx context.Context, exec executor) (*core.Tr
 	return &tx, nil
 }
 
-func (s *Store) GetLastTransaction(ctx context.Context) (*core.Transaction, error) {
+func (s *LedgerStore) GetLastTransaction(ctx context.Context) (*core.Transaction, error) {
 	return s.getLastTransaction(ctx, s.schema)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -60,7 +60,7 @@ func IsTooManyClientError(err error) bool {
 	return IsErrorCode(err, TooManyClient)
 }
 
-type Store interface {
+type LedgerStore interface {
 	GetLastTransaction(ctx context.Context) (*core.Transaction, error)
 	CountTransactions(context.Context, TransactionsQuery) (uint64, error)
 	GetTransactions(context.Context, TransactionsQuery) (sharedapi.Cursor[core.Transaction], error)
@@ -80,7 +80,7 @@ type Store interface {
 
 	LoadMapping(ctx context.Context) (*core.Mapping, error)
 	SaveMapping(ctx context.Context, m core.Mapping) error
-	Initialize(context.Context) (bool, error)
+	Migrate(context.Context) (bool, error)
 	Name() string
 	Close(context.Context) error
 }
@@ -156,7 +156,7 @@ func (n noOpStore) CountMeta(ctx context.Context) (int64, error) {
 	return 0, nil
 }
 
-func (n noOpStore) Initialize(ctx context.Context) (bool, error) {
+func (n noOpStore) Migrate(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
@@ -176,9 +176,15 @@ func (n noOpStore) Close(ctx context.Context) error {
 	return nil
 }
 
-var _ Store = &noOpStore{}
+var _ LedgerStore = &noOpStore{}
 
 func NoOpStore() *noOpStore {
 	return &noOpStore{}
+}
 
+type SystemStore interface {
+	List(ctx context.Context) ([]string, error)
+	Register(ctx context.Context, ledger string) (bool, error)
+	Exists(ctx context.Context, ledger string) (bool, error)
+	Delete(ctx context.Context, ledger string) error
 }


### PR DESCRIPTION
# Introduce system store

This is a refactor if the storage.Driver interface.
The method "GetStore" was renamed to "GetLedgerStore", and a new methods "GetSystemStore" was added (with a SystemStore interface).
The administration methods on the Driver interface (List, Register...) was moved to SystemStore interface.

This give us a better split between ledger dedicated stores and the system store which is common to all ledgers.
