### PR TITLE
feat: add past timestamps flag

### DIFF
--- a/cmd/container.go
+++ b/cmd/container.go
@@ -234,7 +234,7 @@ func NewContainer(v *viper.Viper, userOptions ...fx.Option) *fx.App {
 		fx.Annotate(func() []ledger.LedgerOption {
 			ledgerOptions := []ledger.LedgerOption{}
 
-			if v.GetBool(allowPastTimestampsFlag) {
+			if v.GetString(commitPolicyFlag) == "allow-past-timestamps" {
 				ledgerOptions = append(ledgerOptions, ledger.WithPastTimestamps)
 			}
 

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -230,6 +230,18 @@ func NewContainer(v *viper.Viper, userOptions ...fx.Option) *fx.App {
 		}(),
 	}))
 
+	options = append(options, fx.Provide(
+		fx.Annotate(func() []ledger.LedgerOption {
+			ledgerOptions := []ledger.LedgerOption{}
+
+			if v.GetBool(allowPastTimestampsFlag) {
+				ledgerOptions = append(ledgerOptions, ledger.WithPastTimestamps)
+			}
+
+			return ledgerOptions
+		}, fx.ResultTags(ledger.ResolverLedgerOptionsKey)),
+	))
+
 	// Handle resolver
 	options = append(options,
 		ledger.ResolveModule(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ const (
 	segmentHeartbeatInterval = "segment-heartbeat-interval"
 
 	allowPastTimestampsFlag = "allow-past-timestamps"
+	commitPolicyFlag        = "commit-policy"
 )
 
 var (
@@ -173,6 +174,7 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().String(segmentWriteKey, DefaultSegmentWriteKey, "Segment write key")
 	root.PersistentFlags().Duration(segmentHeartbeatInterval, 24*time.Hour, "Segment heartbeat interval")
 	root.PersistentFlags().Bool(allowPastTimestampsFlag, false, "Allow transactions with timestamps prior to the last transaction to be committed")
+	root.PersistentFlags().String(commitPolicyFlag, "", "Transaction commit policy (default or allow-past-timestamps)")
 
 	internal.InitHTTPBasicFlags(root)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,8 @@ const (
 	segmentWriteKey          = "segment-write-key"
 	segmentApplicationId     = "segment-application-id"
 	segmentHeartbeatInterval = "segment-heartbeat-interval"
+
+	allowPastTimestampsFlag = "allow-past-timestamps"
 )
 
 var (
@@ -170,6 +172,7 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().String(segmentApplicationId, "", "Segment application id")
 	root.PersistentFlags().String(segmentWriteKey, DefaultSegmentWriteKey, "Segment write key")
 	root.PersistentFlags().Duration(segmentHeartbeatInterval, 24*time.Hour, "Segment heartbeat interval")
+	root.PersistentFlags().Bool(allowPastTimestampsFlag, false, "Allow transactions with timestamps prior to the last transaction to be committed")
 
 	internal.InitHTTPBasicFlags(root)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,8 +66,7 @@ const (
 	segmentApplicationId     = "segment-application-id"
 	segmentHeartbeatInterval = "segment-heartbeat-interval"
 
-	allowPastTimestampsFlag = "allow-past-timestamps"
-	commitPolicyFlag        = "commit-policy"
+	commitPolicyFlag = "commit-policy"
 )
 
 var (
@@ -173,7 +172,6 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().String(segmentApplicationId, "", "Segment application id")
 	root.PersistentFlags().String(segmentWriteKey, DefaultSegmentWriteKey, "Segment write key")
 	root.PersistentFlags().Duration(segmentHeartbeatInterval, 24*time.Hour, "Segment heartbeat interval")
-	root.PersistentFlags().Bool(allowPastTimestampsFlag, false, "Allow transactions with timestamps prior to the last transaction to be committed")
 	root.PersistentFlags().String(commitPolicyFlag, "", "Transaction commit policy (default or allow-past-timestamps)")
 
 	internal.InitHTTPBasicFlags(root)

--- a/pkg/api/internal/testing.go
+++ b/pkg/api/internal/testing.go
@@ -257,6 +257,14 @@ func RunTest(t *testing.T, options ...fx.Option) {
 		fx.NopLogger,
 	}, options...)
 
+	options = append(options, fx.Provide(
+		fx.Annotate(func() []ledger.LedgerOption {
+			ledgerOptions := []ledger.LedgerOption{}
+
+			return ledgerOptions
+		}, fx.ResultTags(ledger.ResolverLedgerOptionsKey)),
+	))
+
 	options = append(options, routes.ProvidePerLedgerMiddleware(func() []gin.HandlerFunc {
 		return []gin.HandlerFunc{
 			func(c *gin.Context) {

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -26,17 +26,35 @@ var DefaultContracts = []core.Contract{
 }
 
 type Ledger struct {
-	locker  Locker
-	store   storage.Store
-	monitor Monitor
+	locker              Locker
+	store               storage.Store
+	monitor             Monitor
+	allowPastTimestamps bool
 }
 
-func NewLedger(store storage.Store, locker Locker, monitor Monitor) (*Ledger, error) {
-	return &Ledger{
+type LedgerOption = func(*Ledger)
+
+func WithPastTimestamps(l *Ledger) {
+	l.allowPastTimestamps = true
+}
+
+func NewLedger(
+	store storage.Store,
+	locker Locker,
+	monitor Monitor,
+	options ...LedgerOption,
+) (*Ledger, error) {
+	l := &Ledger{
 		store:   store,
 		locker:  locker,
 		monitor: monitor,
-	}, nil
+	}
+
+	for _, option := range options {
+		option(l)
+	}
+
+	return l, nil
 }
 
 func (l *Ledger) Close(ctx context.Context) error {

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -56,7 +56,7 @@ func withContainer(options ...fx.Option) {
 	}
 }
 
-func runOnLedger(f func(l *Ledger)) {
+func runOnLedger(f func(l *Ledger), ledgerOptions ...LedgerOption) {
 	withContainer(fx.Invoke(func(lc fx.Lifecycle, storageDriver storage.Driver) {
 		lc.Append(fx.Hook{
 			OnStart: func(ctx context.Context) error {
@@ -69,7 +69,7 @@ func runOnLedger(f func(l *Ledger)) {
 				if err != nil {
 					return err
 				}
-				l, err := NewLedger(store, NewInMemoryLocker(), &noOpMonitor{})
+				l, err := NewLedger(store, NewInMemoryLocker(), &noOpMonitor{}, ledgerOptions...)
 				if err != nil {
 					panic(err)
 				}

--- a/pkg/ledger/process.go
+++ b/pkg/ledger/process.go
@@ -36,10 +36,15 @@ func (l *Ledger) processTx(ctx context.Context, ts []core.TransactionData) (*Com
 
 	usedReferences := make(map[string]struct{})
 	for i, t := range ts {
+		past := false
 		if t.Timestamp.IsZero() {
 			// Until v1.5.0, dates was stored as string using rfc3339 format
 			// So round the date to the second to keep the same behaviour
 			t.Timestamp = time.Now().UTC().Truncate(time.Second)
+		} else {
+			if lastTx != nil && t.Timestamp.Before(lastTx.Timestamp) {
+				past = true
+			}
 		}
 		if t.Reference != "" {
 			if _, ok := usedReferences[t.Reference]; ok {
@@ -57,7 +62,7 @@ func (l *Ledger) processTx(ctx context.Context, ts []core.TransactionData) (*Com
 		if len(t.Postings) == 0 {
 			return nil, NewTransactionCommitError(i, NewValidationError("transaction has no postings"))
 		}
-		if lastTx != nil && t.Timestamp.Before(lastTx.Timestamp) {
+		if past && !l.allowPastTimestamps {
 			return nil, NewTransactionCommitError(i, NewValidationError("cannot pass a date prior to the last transaction"))
 		}
 

--- a/pkg/ledger/process_test.go
+++ b/pkg/ledger/process_test.go
@@ -305,8 +305,12 @@ func TestLedger_processTx(t *testing.T) {
 					Timestamp: now.Add(-time.Second),
 				},
 			})
-			assert.Error(t, err)
-			assert.True(t, IsValidationError(err))
+			if l.allowPastTimestamps {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.True(t, IsValidationError(err))
+			}
 		})
 	})
 }


### PR DESCRIPTION
This PR adds a flag to be used in history ingestion scenario where we want to create transactions in the past. The existing timestamp over

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?
The transaction commit validation system.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
