### PR TITLE
fix: Add wget to generated image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     -X github.com/numary/ledger/cmd.DefaultSegmentWriteKey=${SEGMENT_WRITE_KEY}" ./
 
 FROM ubuntu:jammy
-RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y ca-certificates wget && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /go/src/github.com/numary/ledger/numary /usr/local/bin/numary
 EXPOSE 3068
 ENTRYPOINT ["numary"]


### PR DESCRIPTION
# Fix missing wget

This add wget to the generated image allowing health check of docker compose to run successfully.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt
