### PR TITLE
fix: revert event

### DIFF
--- a/pkg/core/transaction.go
+++ b/pkg/core/transaction.go
@@ -19,7 +19,8 @@ type TransactionData struct {
 }
 
 func (t *TransactionData) Reverse() TransactionData {
-	postings := t.Postings
+	postings := make(Postings, len(t.Postings))
+	copy(postings, t.Postings)
 	postings.Reverse()
 
 	ret := TransactionData{

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -173,6 +173,11 @@ func (l *Ledger) RevertTransaction(ctx context.Context, id uint64) (*core.Expand
 		return nil, err
 	}
 
+	if revertedTx.Metadata == nil {
+		revertedTx.Metadata = core.Metadata{}
+	}
+	revertedTx.Metadata.Merge(core.RevertedMetadata(revert.ID))
+
 	l.monitor.RevertedTransaction(ctx, l.store.Name(), revertedTx, &result.GeneratedTransactions[0])
 	return &result.GeneratedTransactions[0], nil
 }


### PR DESCRIPTION
# Fix: revert event

This fix error on revert event.
The field 'revertedTx' of the event was containing reverted tx instead of original postings, and the metadata indicating the revert was missing.
There are no test since a complete integration test branch is coming in a few days.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt

## What parts of the code are impacted ?
__Please describe the impacted parts of the code.__

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
